### PR TITLE
Custom error class for minimum amount error

### DIFF
--- a/connect/src/routes/tokenBridge/automatic.ts
+++ b/connect/src/routes/tokenBridge/automatic.ts
@@ -14,6 +14,9 @@ import { TransferState } from "../../types.js";
 import { Wormhole } from "../../wormhole.js";
 import type { StaticRouteMethods } from "../route.js";
 import { AutomaticRoute } from "../route.js";
+import {
+  MinAmountError,
+} from '../types.js';
 import type {
   Quote,
   QuoteResult,
@@ -167,12 +170,7 @@ export class AutomaticTokenBridgeRoute<N extends Network>
     // Min amount is fee + 5%
     const minAmount = (fee * 105n) / 100n;
     if (amount.units(amt) < minAmount) {
-      throw new Error(
-        `Minimum amount is ${amount.display({
-          amount: minAmount.toString(),
-          decimals: amt.decimals,
-        })}`,
-      );
+      throw new MinAmountError(amount.fromBaseUnits(minAmount, amt.decimals));
     }
 
     const redeemableAmount = amount.units(amt) - fee;

--- a/connect/src/routes/types.ts
+++ b/connect/src/routes/types.ts
@@ -100,3 +100,14 @@ export class MinAmountError extends Error {
     return this.min;
   }
 }
+
+// Special error to return from quote() or validate() when the
+// protocol can't provide a quote.
+export class UnavailableError extends Error {
+  internalError: Error;
+
+  constructor(internalErr: Error) {
+    super(`Unable to fetch a quote`);
+    this.internalError = internalErr;
+  }
+}

--- a/connect/src/routes/types.ts
+++ b/connect/src/routes/types.ts
@@ -1,6 +1,6 @@
 import type { TokenId } from "@wormhole-foundation/sdk-definitions";
 import type { AttestationReceipt, TransferReceipt } from "../types.js";
-import type { amount } from "@wormhole-foundation/sdk-base";
+import { amount } from "@wormhole-foundation/sdk-base";
 import type { QuoteWarning } from "../warnings.js";
 
 // Extend Options to provide custom options
@@ -84,3 +84,19 @@ export type QuoteError = {
   success: false;
   error: Error;
 };
+
+// Special error to return from quote() or validate() when the
+// given transfer amount is too small. Used to helpfully
+// show a minimum amount in the interface.
+export class MinAmountError extends Error {
+  min: amount.Amount;
+
+  constructor(min: amount.Amount) {
+    super(`Minimum transfer amount is ${amount.display(min)}`);
+    this.min = min;
+  }
+
+  minAmount(): amount.Amount {
+    return this.min;
+  }
+}


### PR DESCRIPTION
This should be used to communicate that `validate()` or `quote()` have failed, but only because the user's transfer amount was too small. UI should use this to show a helpful error so the user can increase their transfer size.