### PR TITLE
Bug: default must be last

### DIFF
--- a/connect/package.json
+++ b/connect/package.json
@@ -25,8 +25,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   },

--- a/core/base/package.json
+++ b/core/base/package.json
@@ -23,8 +23,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   },

--- a/core/definitions/package.json
+++ b/core/definitions/package.json
@@ -22,34 +22,34 @@
   "exports": {
     ".": {
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       },
       "import": {
-        "default": "./dist/esm/index.js",
-        "types": "./dist/esm/index.d.ts"
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
       }
     },
     "./testing": {
       "require": {
-        "default": "./dist/cjs/testing/index.js",
-        "types": "./dist/cjs/testing/index.d.ts"
+        "types": "./dist/cjs/testing/index.d.ts",
+        "default": "./dist/cjs/testing/index.js"
       },
       "import": {
-        "default": "./dist/esm/testing/index.js",
-        "types": "./dist/esm/testing/index.d.ts"
+        "types": "./dist/esm/testing/index.d.ts",
+        "default": "./dist/esm/testing/index.js"
       }
     }
   },
   "typesVersions": {
     "*": {
-      "*": [
-        "./dist/cjs/index.d.ts",
-        "./dist/esm/index.d.ts"
-      ],
       "testing": [
         "./dist/cjs/testing/index.d.ts",
         "./dist/esm/testing/index.d.ts"
+      ],
+      "*": [
+        "./dist/cjs/index.d.ts",
+        "./dist/esm/index.d.ts"
       ]
     }
   },

--- a/platforms/algorand/package.json
+++ b/platforms/algorand/package.json
@@ -24,8 +24,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   },

--- a/platforms/algorand/protocols/core/package.json
+++ b/platforms/algorand/protocols/core/package.json
@@ -53,8 +53,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/algorand/protocols/tokenBridge/package.json
+++ b/platforms/algorand/protocols/tokenBridge/package.json
@@ -54,8 +54,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/aptos/package.json
+++ b/platforms/aptos/package.json
@@ -54,8 +54,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/aptos/protocols/core/package.json
+++ b/platforms/aptos/protocols/core/package.json
@@ -56,8 +56,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/aptos/protocols/tokenBridge/package.json
+++ b/platforms/aptos/protocols/tokenBridge/package.json
@@ -57,8 +57,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/cosmwasm/package.json
+++ b/platforms/cosmwasm/package.json
@@ -67,8 +67,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/cosmwasm/protocols/core/package.json
+++ b/platforms/cosmwasm/protocols/core/package.json
@@ -63,8 +63,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/cosmwasm/protocols/ibc/package.json
+++ b/platforms/cosmwasm/protocols/ibc/package.json
@@ -65,8 +65,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/cosmwasm/protocols/tokenBridge/package.json
+++ b/platforms/cosmwasm/protocols/tokenBridge/package.json
@@ -63,8 +63,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/evm/package.json
+++ b/platforms/evm/package.json
@@ -74,8 +74,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/evm/protocols/cctp/package.json
+++ b/platforms/evm/protocols/cctp/package.json
@@ -64,8 +64,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/evm/protocols/core/package.json
+++ b/platforms/evm/protocols/core/package.json
@@ -63,8 +63,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/evm/protocols/portico/package.json
+++ b/platforms/evm/protocols/portico/package.json
@@ -65,8 +65,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/evm/protocols/tokenBridge/package.json
+++ b/platforms/evm/protocols/tokenBridge/package.json
@@ -64,8 +64,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/solana/package.json
+++ b/platforms/solana/package.json
@@ -61,8 +61,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/solana/protocols/cctp/package.json
+++ b/platforms/solana/protocols/cctp/package.json
@@ -65,8 +65,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/solana/protocols/core/package.json
+++ b/platforms/solana/protocols/core/package.json
@@ -62,8 +62,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/solana/protocols/tokenBridge/package.json
+++ b/platforms/solana/protocols/tokenBridge/package.json
@@ -62,8 +62,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/sui/package.json
+++ b/platforms/sui/package.json
@@ -53,8 +53,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/sui/protocols/core/package.json
+++ b/platforms/sui/protocols/core/package.json
@@ -53,8 +53,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/platforms/sui/protocols/tokenBridge/package.json
+++ b/platforms/sui/protocols/tokenBridge/package.json
@@ -54,8 +54,8 @@
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -116,10 +116,6 @@
   },
   "typesVersions": {
     "*": {
-      "*": [
-        "dist/cjs/index.d.ts",
-        "dist/esm/index.d.ts"
-      ],
       "algorand": [
         "dist/cjs/algorand.d.ts",
         "dist/esm/algorand.d.ts"
@@ -143,6 +139,10 @@
       "sui": [
         "dist/cjs/sui.d.ts",
         "dist/esm/sui.d.ts"
+      ],
+      "*": [
+        "dist/cjs/index.d.ts",
+        "dist/esm/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
_strange_

without this change next complains about module resolution
![image](https://github.com/wormhole-foundation/wormhole-sdk-ts/assets/520236/cf7310f7-5220-4ccf-8d7f-d36f34d7635f)

with this change, its resolved properly
![image](https://github.com/wormhole-foundation/wormhole-sdk-ts/assets/520236/5ca13a22-5603-4516-ae5e-6b4ae1dbb1a8)

notably changing `moduleResolution` in `tsconfig.json` from default of `bundler` to `Node16` allowed resolution to happen

linking for https://github.com/vercel/next.js/issues/39375
