### PR TITLE
Fix partial config issue with token map

### DIFF
--- a/connect/src/config.ts
+++ b/connect/src/config.ts
@@ -19,7 +19,7 @@ type RecursivePartial<T> = {
     : T[P];
 };
 
-export type ConfigOverrides = RecursivePartial<WormholeConfig>;
+export type ConfigOverrides<N extends Network> = RecursivePartial<WormholeConfig<N>>;
 
 export const CONFIG = {
   Mainnet: {
@@ -53,13 +53,14 @@ export function networkPlatformConfigs<N extends Network, P extends Platform>(
 // Apply any overrides to the base config
 export function applyOverrides<N extends Network>(
   network: N,
-  overrides?: ConfigOverrides,
+  overrides?: ConfigOverrides<N>,
 ): WormholeConfig {
   let base = CONFIG[network];
   if (!overrides) return base;
 
   // recurse through the overrides and apply them to the base config
   function override(base: any, overrides: any) {
+    if (!base) base = {};
     for (const [key, value] of Object.entries(overrides)) {
       if (typeof value === "object" && !Array.isArray(value)) {
         base[key] = override(base[key], value);

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -48,7 +48,7 @@ export class Wormhole<N extends Network> {
 
   readonly config: WormholeConfig;
 
-  constructor(network: N, platforms: PlatformUtils<any>[], config?: ConfigOverrides) {
+  constructor(network: N, platforms: PlatformUtils<any>[], config?: ConfigOverrides<N>) {
     this._network = network;
     this.config = applyOverrides(network, config);
 

--- a/examples/src/config.ts
+++ b/examples/src/config.ts
@@ -1,5 +1,5 @@
 import { wormhole } from "@wormhole-foundation/sdk";
-import { solana } from "@wormhole-foundation/sdk/solana";
+import solana from "@wormhole-foundation/sdk/solana";
 
 (async function () {
   // EXAMPLE_CONFIG_OVERRIDE

--- a/examples/src/router.ts
+++ b/examples/src/router.ts
@@ -4,6 +4,7 @@ import {
   Signer,
   TransactionId,
   TransferState,
+  Wormhole,
   canonicalAddress,
   routes,
   wormhole,
@@ -15,10 +16,24 @@ import { getSigner } from "./helpers/index.js";
 
 (async function () {
   // Setup
-  const wh = await wormhole("Testnet", [evm, solana]);
+  const wh = await wormhole("Testnet", [evm, solana], {
+    chains: {
+      Sepolia: {
+        tokenMap: {
+          MySweetToken: {
+            key: "MySweetToken",
+            decimals: 18,
+            address: "0x7E399fd2C4B260b1cBC66548c03753aBA9990665",
+            chain: "Sepolia",
+            symbol: "MST",
+          },
+        },
+      },
+    },
+  });
 
   // Get chain contexts
-  const sendChain = wh.getChain("Avalanche");
+  const sendChain = wh.getChain("Sepolia");
   const destChain = wh.getChain("Solana");
 
   // get signers from local config
@@ -43,8 +58,10 @@ import { getSigner } from "./helpers/index.js";
     "Allowed source tokens: ",
     srcTokens.map((t) => canonicalAddress(t)),
   );
+
+  const sendToken = Wormhole.tokenId("Sepolia", "0x7E399fd2C4B260b1cBC66548c03753aBA9990665");
   // Grab the first one for the example
-  const sendToken = srcTokens[0]!;
+  //const sendToken = srcTokens[0]!;
 
   // given the send token, what can we possibly get on the destination chain?
   const destTokens = await resolver.supportedDestinationTokens(sendToken, sendChain, destChain);

--- a/examples/src/router.ts
+++ b/examples/src/router.ts
@@ -4,7 +4,6 @@ import {
   Signer,
   TransactionId,
   TransferState,
-  Wormhole,
   canonicalAddress,
   routes,
   wormhole,
@@ -16,24 +15,10 @@ import { getSigner } from "./helpers/index.js";
 
 (async function () {
   // Setup
-  const wh = await wormhole("Testnet", [evm, solana], {
-    chains: {
-      Sepolia: {
-        tokenMap: {
-          MySweetToken: {
-            key: "MySweetToken",
-            decimals: 18,
-            address: "0x7E399fd2C4B260b1cBC66548c03753aBA9990665",
-            chain: "Sepolia",
-            symbol: "MST",
-          },
-        },
-      },
-    },
-  });
+  const wh = await wormhole("Testnet", [evm, solana]);
 
   // Get chain contexts
-  const sendChain = wh.getChain("Sepolia");
+  const sendChain = wh.getChain("Avalanche");
   const destChain = wh.getChain("Solana");
 
   // get signers from local config
@@ -59,9 +44,8 @@ import { getSigner } from "./helpers/index.js";
     srcTokens.map((t) => canonicalAddress(t)),
   );
 
-  const sendToken = Wormhole.tokenId("Sepolia", "0x7E399fd2C4B260b1cBC66548c03753aBA9990665");
   // Grab the first one for the example
-  //const sendToken = srcTokens[0]!;
+  const sendToken = srcTokens[0]!;
 
   // given the send token, what can we possibly get on the destination chain?
   const destTokens = await resolver.supportedDestinationTokens(sendToken, sendChain, destChain);

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -38,7 +38,7 @@ export interface PlatformDefinition<
 export async function wormhole<N extends Network>(
   network: N,
   platformLoaders: (() => Promise<PlatformDefinition>)[],
-  config?: ConfigOverrides,
+  config?: ConfigOverrides<N>,
 ): Promise<Wormhole<N>> {
   // make sure all protocols are loaded
   try {


### PR DESCRIPTION
While debugging #431, I found that the intended method of providing tokens to the partial config overrides would fail while trying to set properties on an undefined object.

This provides a default empty object for the `base` value if its not set and properly sets the Network generic param on the Config type