### PR TITLE
Definitions: Allow contracts to be passed to the `getProtocol` fn

### DIFF
--- a/core/definitions/src/chain.ts
+++ b/core/definitions/src/chain.ts
@@ -195,13 +195,14 @@ export abstract class ChainContext<
   async getProtocol<PN extends ProtocolName>(
     protocolName: ProtocolName,
     rpc?: RpcConnection<P>,
+    contracts: any = this.config.contracts,
   ): Promise<ProtocolImplementation<P, PN>> {
     if (!this.protocols.has(protocolName)) {
       const ctor = this.platform.getProtocolInitializer(protocolName);
 
       const protocol = rpc
         ? await this.platform.getProtocol(protocolName, rpc)
-        : new ctor(this.network, this.chain, await this.getRpc(), this.config.contracts);
+        : new ctor(this.network, this.chain, await this.getRpc(), contracts);
 
       this.protocols.set(protocolName, protocol);
     }

--- a/core/definitions/src/chain.ts
+++ b/core/definitions/src/chain.ts
@@ -3,6 +3,14 @@ import { tokens } from "@wormhole-foundation/sdk-base";
 import type { ChainAddress, UniversalOrNative } from "./address.js";
 import { toNative } from "./address.js";
 import type { WormholeMessageId } from "./attestation.js";
+import {
+  AutomaticCircleBridge,
+  CircleBridge,
+  Contracts,
+  IbcBridge,
+  PorticoBridge,
+  WormholeCore,
+} from "./index.js";
 import type { PlatformContext } from "./platform.js";
 import type { ProtocolImplementation, ProtocolName } from "./protocol.js";
 import { protocolIsRegistered } from "./protocol.js";
@@ -10,13 +18,6 @@ import type { AutomaticTokenBridge, TokenBridge } from "./protocols/tokenBridge/
 import type { RpcConnection } from "./rpc.js";
 import type { ChainConfig, SignedTx, TokenAddress, TokenId } from "./types.js";
 import { canonicalAddress, isNative } from "./types.js";
-import {
-  AutomaticCircleBridge,
-  CircleBridge,
-  IbcBridge,
-  PorticoBridge,
-  WormholeCore,
-} from "./index.js";
 
 /**
  * A ChainContext provides a consistent interface for interacting with a chain.
@@ -194,8 +195,8 @@ export abstract class ChainContext<
    */
   async getProtocol<PN extends ProtocolName>(
     protocolName: ProtocolName,
+    contracts: Contracts = this.config.contracts,
     rpc?: RpcConnection<P>,
-    contracts: any = this.config.contracts,
   ): Promise<ProtocolImplementation<P, PN>> {
     if (!this.protocols.has(protocolName)) {
       const ctor = this.platform.getProtocolInitializer(protocolName);

--- a/core/definitions/src/contracts.ts
+++ b/core/definitions/src/contracts.ts
@@ -1,8 +1,12 @@
 import type { Chain, Network } from "@wormhole-foundation/sdk-base";
 import { contracts } from "@wormhole-foundation/sdk-base";
 
+// Allow contracts to be passed that arent
+// part of the known contract set
+type UnknownContracts = Record<string, any>;
+
 /** The Contract addresses set in configuration for a given chain */
-export interface Contracts {
+export type Contracts = {
   coreBridge?: string;
   tokenBridge?: string;
   tokenBridgeRelayer?: string;
@@ -12,7 +16,7 @@ export interface Contracts {
   gateway?: string;
   translator?: string;
   portico?: contracts.PorticoContracts;
-}
+} & UnknownContracts;
 
 /**
  *


### PR DESCRIPTION
Calling `getProtocol` on an instance of a chain should provide a way to pass contract overrides or additional contracts that are not part of the default set.

Without this change, its necessary to get the protocol initializer from the platform _then_ init it with the contracts + overrides
https://github.com/wormhole-foundation/example-native-token-transfers/blob/barnji/ts-sdk/sdk/__tests__/utils.ts#L199-L206