### PR TITLE
SDK: Export addresses from index

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,6 +9,8 @@ import {
 
 export * from "@wormhole-foundation/sdk-connect";
 
+export * from "./addresses.js";
+
 export interface PlatformDefinition<P extends Platform> {
   Platform: PlatformUtils<P>;
   Address: NativeAddressCtr;


### PR DESCRIPTION
This extra import ensures the addresses of all platforms are registered and available to the runtime if anything is imported, no need to remember an extra import to parse addresses 