### PR TITLE
Connect: Transfer State updates

### DIFF
--- a/connect/src/protocols/cctpTransfer.ts
+++ b/connect/src/protocols/cctpTransfer.ts
@@ -28,6 +28,7 @@ import type {
   AttestationReceipt,
   AttestedTransferReceipt,
   CompletedTransferReceipt,
+  RedeemedTransferReceipt,
   SourceFinalizedTransferReceipt,
   SourceInitiatedTransferReceipt,
   TransferQuote,
@@ -567,7 +568,7 @@ export class CircleTransfer<N extends Network = Network>
         ...(receipt as AttestedTransferReceipt<CircleAttestationReceipt>),
         state: TransferState.DestinationInitiated,
         destinationTxs,
-      } satisfies CompletedTransferReceipt<CircleAttestationReceipt>;
+      } satisfies RedeemedTransferReceipt<CircleAttestationReceipt>;
     }
 
     return receipt;
@@ -688,10 +689,10 @@ export class CircleTransfer<N extends Network = Network>
         if (txStatus && txStatus.globalTx?.destinationTx?.txHash) {
           const { chainId, txHash } = txStatus.globalTx.destinationTx;
           receipt = {
-            ...receipt,
+            ...(receipt as AttestedTransferReceipt<CircleAttestationReceipt, SC, DC>),
             destinationTxs: [{ chain: toChain(chainId) as DC, txid: txHash }],
-            state: TransferState.DestinationFinalized,
-          } satisfies CompletedTransferReceipt<CircleAttestationReceipt>;
+            state: TransferState.DestinationInitiated,
+          } satisfies RedeemedTransferReceipt<CircleAttestationReceipt>;
           yield receipt;
         }
       }

--- a/connect/src/protocols/tokenTransfer.ts
+++ b/connect/src/protocols/tokenTransfer.ts
@@ -31,6 +31,7 @@ import type {
   AttestationReceipt,
   AttestedTransferReceipt,
   CompletedTransferReceipt,
+  RedeemedTransferReceipt,
   SourceFinalizedTransferReceipt,
   SourceInitiatedTransferReceipt,
   TransferQuote,
@@ -638,7 +639,7 @@ export class TokenTransfer<N extends Network = Network>
     if (destinationTxs.length > 0) {
       receipt = {
         ...(receipt as AttestedTransferReceipt<TokenTransferAttestationReceipt>),
-        state: TransferState.DestinationInitiated,
+        state: TransferState.DestinationFinalized,
         destinationTxs: destinationTxs,
       } satisfies CompletedTransferReceipt<TokenTransferAttestationReceipt>;
     }
@@ -704,8 +705,8 @@ export class TokenTransfer<N extends Network = Network>
         receipt = {
           ...receipt,
           destinationTxs: [{ chain: toChainName(chainId) as DC, txid: txHash }],
-          state: TransferState.DestinationFinalized,
-        } satisfies CompletedTransferReceipt<TokenTransferAttestationReceipt>;
+          state: TransferState.DestinationInitiated,
+        } satisfies RedeemedTransferReceipt<TokenTransferAttestationReceipt>;
       }
       yield receipt;
     }

--- a/core/definitions/src/attestation.ts
+++ b/core/definitions/src/attestation.ts
@@ -24,7 +24,7 @@ export type AttestationId<PN extends ProtocolName = ProtocolName> = PN extends
   ? CircleMessageId
   : PN extends "IbcBridge"
   ? IbcMessageId
-  : never;
+  : any;
 
 /**
  * The full attestation that represents evidence of a transaction
@@ -43,7 +43,7 @@ export type Attestation<PN extends ProtocolName = ProtocolName> = PN extends
   ? VAA<"Uint8Array">
   : PN extends "PorticoBridge"
   ? PorticoBridge.VAA
-  : never;
+  : any;
 
 /**
  * Wormhole Message Identifier used to fetch a VAA


### PR DESCRIPTION
A redeemed state should be defined and set in the case the transfer has been delivered/redeemed but not seen to be finalized yet