### PR TITLE
Add missing dependencies to protocol pkgs

### DIFF
--- a/platforms/cosmwasm/protocols/core/package.json
+++ b/platforms/cosmwasm/protocols/core/package.json
@@ -55,7 +55,8 @@
     "@wormhole-foundation/sdk-connect": "0.5.3-beta.5",
     "@wormhole-foundation/sdk-cosmwasm": "0.5.3-beta.5",
     "@cosmjs/cosmwasm-stargate": "^0.32.0",
-    "@cosmjs/stargate": "^0.32.0"
+    "@cosmjs/stargate": "^0.32.0",
+    "@injectivelabs/sdk-ts": "^1.14.4"
   },
   "type": "module",
   "exports": {

--- a/platforms/cosmwasm/protocols/ibc/package.json
+++ b/platforms/cosmwasm/protocols/ibc/package.json
@@ -56,6 +56,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.0",
     "@cosmjs/stargate": "^0.32.0",
     "cosmjs-types": "^0.9.0",
+    "@injectivelabs/sdk-ts": "^1.14.4",
     "@wormhole-foundation/sdk-connect": "0.5.3-beta.5",
     "@wormhole-foundation/sdk-cosmwasm": "0.5.3-beta.5",
     "@wormhole-foundation/sdk-cosmwasm-core": "0.5.3-beta.5"

--- a/platforms/cosmwasm/protocols/tokenBridge/package.json
+++ b/platforms/cosmwasm/protocols/tokenBridge/package.json
@@ -52,6 +52,7 @@
     "prettier": "prettier --write ./src"
   },
   "dependencies": {
+    "@injectivelabs/sdk-ts": "^1.14.4",
     "@cosmjs/cosmwasm-stargate": "^0.32.0",
     "@wormhole-foundation/sdk-connect": "0.5.3-beta.5",
     "@wormhole-foundation/sdk-cosmwasm": "0.5.3-beta.5"

--- a/platforms/solana/protocols/core/src/utils/instructions/verifySignature.ts
+++ b/platforms/solana/protocols/core/src/utils/instructions/verifySignature.ts
@@ -6,17 +6,13 @@ import type {
 } from '@solana/web3.js';
 import {
   PublicKey,
-  SystemProgram,
   SYSVAR_INSTRUCTIONS_PUBKEY,
   SYSVAR_RENT_PUBKEY,
+  SystemProgram,
 } from '@solana/web3.js';
-import {
-  getGuardianSet,
-  deriveGuardianSetKey,
-  getWormholeBridgeData,
-} from './../accounts/index.js';
-import { createReadOnlyWormholeProgramInterface } from '../program.js';
 import type { VAA } from '@wormhole-foundation/sdk-connect';
+import { createReadOnlyWormholeProgramInterface } from '../program.js';
+import { deriveGuardianSetKey, getGuardianSet } from './../accounts/index.js';
 import { createSecp256k1Instruction } from './secp256k1.js';
 
 const MAX_LEN_GUARDIAN_KEYS = 19;
@@ -49,11 +45,6 @@ export async function createVerifySignaturesInstructions(
   commitment?: Commitment,
 ): Promise<TransactionInstruction[]> {
   const guardianSetIndex = vaa.guardianSet;
-  const info = await getWormholeBridgeData(connection, wormholeProgramId);
-
-  if (guardianSetIndex != info.guardianSetIndex)
-    throw new Error('guardianSetIndex != config.guardianSetIndex');
-
   const guardianSetData = await getGuardianSet(
     connection,
     wormholeProgramId,

--- a/platforms/sui/protocols/core/package.json
+++ b/platforms/sui/protocols/core/package.json
@@ -45,6 +45,7 @@
     "prettier": "prettier --write ./src"
   },
   "dependencies": {
+    "@mysten/sui.js": "^0.50.1",
     "@wormhole-foundation/sdk-connect": "0.5.3-beta.5",
     "@wormhole-foundation/sdk-sui": "0.5.3-beta.5"
   },

--- a/platforms/sui/protocols/tokenBridge/package.json
+++ b/platforms/sui/protocols/tokenBridge/package.json
@@ -45,6 +45,7 @@
     "prettier": "prettier --write ./src"
   },
   "dependencies": {
+    "@mysten/sui.js": "^0.50.1",
     "@wormhole-foundation/sdk-connect": "0.5.3-beta.5",
     "@wormhole-foundation/sdk-sui": "0.5.3-beta.5",
     "@wormhole-foundation/sdk-sui-core": "0.5.3-beta.5"


### PR DESCRIPTION
This should hopefully resolve errors I've been getting when trying to use this SDK in Connect. Both `@mysten/sui.js` and `@injectivelabs/sdk-ts` were resolving to the wrong version.