### PR TITLE
Protocols: Add `VersionedProtocolInitializer`

### DIFF
--- a/core/definitions/src/protocol.ts
+++ b/core/definitions/src/protocol.ts
@@ -55,6 +55,7 @@ export interface ProtocolInitializer<
     chain: C,
     connection: RpcConnection<P>,
     contracts: Contracts,
+    version?: string,
   ): ProtocolInterface<PN, N, C>;
   /** fromRpc will create a new instance of the Protocol client given the RPC and the config
    * @param rpc - the RPC connection to the chain, used to query the chain for its native chain id
@@ -64,6 +65,20 @@ export interface ProtocolInitializer<
     rpc: RpcConnection<P>,
     config: ChainsConfig<Network, P>,
   ): Promise<ProtocolInterface<PN, N, C>>;
+}
+
+export interface VersionedProtocolInitializer<
+  P extends Platform,
+  PN extends ProtocolName,
+  N extends Network,
+> extends ProtocolInitializer<P, PN, N> {
+  getVersion(rpc: RpcConnection<P>, Contracts: Contracts): Promise<string>;
+}
+
+export function isVersionedProtocolInitializer(
+  ctr: ProtocolInitializer<Platform, ProtocolName, Network>,
+): ctr is VersionedProtocolInitializer<Platform, ProtocolName, Network> {
+  return "getVersion" in ctr;
 }
 
 export type ProtocolInstance<


### PR DESCRIPTION
In order to support Protocol clients that may have versioned bindings, a new type is added that signals it can be invoked to fetch the version.

This is the first place in the SDK we're doing this and its meant to support the different bindings a given Ntt contract may require.

Without this change the only way to get the version checked (through "normal" use) is by first setting the config in base (that means 1 copy of `ntt` possible)

then calling:
```ts
chain.getProtocol("Ntt", undefined, await chain.getRpc())
```

which causes the `fromRpc` method on the protocol initializer to fire and fetch the version from the contract on-chain.


