### PR TITLE
implement option layout item

### DIFF
--- a/core/base/src/utils/layout/utils.ts
+++ b/core/base/src/utils/layout/utils.ts
@@ -54,7 +54,11 @@ type CombineObjects<T, U> = {
 };
 
 export type BytesBase =
-  { readonly name: string } & Omit<BytesLayoutItem, "binary" | "custom" | "layout">;
+  Partial<CombineObjects<
+    { readonly name: string },
+    Omit<BytesLayoutItem, "binary" | "custom" | "layout">
+  >>;
+
 
 export type CustomizableBytesReturn<B extends BytesBase, P extends CustomizableBytes> =
   CombineObjects<


### PR DESCRIPTION
Implement a nice, uniform way to handle Rust-like options in layouting.

There are two TODOs in the code regarding two casts which I don't understand why I'd have to make them.

And ofc, there are no tests, because who has time to write those? Not me!