### PR TITLE
add guardian set index to mock guardian signer

### DIFF
--- a/core/definitions/src/testing/mocks/guardian.ts
+++ b/core/definitions/src/testing/mocks/guardian.ts
@@ -30,6 +30,13 @@ export class MockGuardians {
 
     const vaa = deserialize("Uint8Array", message);
 
+    if (vaa.guardianSet === 0)
+      // @ts-ignore -- wants readonly
+      vaa.guardianSet = this.setIndex;
+
+    if (vaa.guardianSet != this.setIndex)
+      throw new Error(`Mismatched guardian set index: ${vaa.guardianSet} != ${this.setIndex}`);
+
     for (let i = 0; i < signers.length; ++i) {
       const signer = signers.at(i);
       if (!signer) throw Error("No signer with index: " + i);


### PR DESCRIPTION
We no longer construct the VAA from scratch as is done in the original implementation so we need to check for and set the guardian set index or error if we get a VAA with one we're not expecting