### PR TITLE
Solana: Refactor Solana signer, Add config options

### DIFF
--- a/examples/src/helpers/helpers.ts
+++ b/examples/src/helpers/helpers.ts
@@ -28,7 +28,7 @@ function getEnv(key: string): string {
 
   // Otherwise, return the env var or error
   const val = process.env[key];
-  if (!val) throw new Error(`Missing env var ${key}, did you forget to set valies in '.env'?`);
+  if (!val) throw new Error(`Missing env var ${key}, did you forget to set values in '.env'?`);
 
   return val;
 }

--- a/examples/src/helpers/helpers.ts
+++ b/examples/src/helpers/helpers.ts
@@ -54,7 +54,7 @@ export async function getSigner<N extends Network, C extends Chain>(
         priorityFee: {
           // take the middle priority fee
           percentile: 0.5,
-          // but juice it
+          // juice the base fee taken from priority fee percentile
           percentileMultiple: 2,
           // at least 1 lamport/compute unit
           min: 1,

--- a/examples/src/helpers/helpers.ts
+++ b/examples/src/helpers/helpers.ts
@@ -50,8 +50,17 @@ export async function getSigner<N extends Network, C extends Chain>(
   switch (platform) {
     case "Solana":
       signer = await solana.getSigner(await chain.getRpc(), getEnv("SOL_PRIVATE_KEY"), {
-        //debug: true,
-        priorityFeePercentile: 0.9,
+        debug: true,
+        priorityFee: {
+          // take the middle priority fee
+          percentile: 0.5,
+          // but juice it
+          percentileMultiple: 2,
+          // at least 1 lamport/compute unit
+          min: 1,
+          // at most 1000 lamport/compute unit
+          max: 1000,
+        },
       });
       break;
     case "Cosmwasm":

--- a/platforms/solana/src/signer.ts
+++ b/platforms/solana/src/signer.ts
@@ -245,20 +245,25 @@ export class SolanaSendSigner<
       }
     }
 
-    if (this._debug) console.log('Waiting for finalization: ', txids);
+    if (this._debug) console.log('Waiting for confirmation for: ', txids);
 
     // Wait for finalization
     const results = await Promise.all(
-      txids.map((signature) =>
-        this._rpc.confirmTransaction(
-          {
-            signature,
-            blockhash,
-            lastValidBlockHeight,
-          },
-          this._rpc.commitment,
-        ),
-      ),
+      txids.map(async (signature) => {
+        try {
+          return await this._rpc.confirmTransaction(
+            {
+              signature,
+              blockhash,
+              lastValidBlockHeight,
+            },
+            this._rpc.commitment,
+          );
+        } catch (e) {
+          console.error('Failed to confirm transaction: ', e);
+          throw e;
+        }
+      }),
     );
 
     const erroredTxs = results


### PR DESCRIPTION
My reasoning for the `percentileMultiple` config setting was that the percentile thing is

1) limited to only whatever happened in the recent transactions
2) may be impacted by insanely high values


If you're having trouble landing txs and you max it to 1.0, the highest fee paid wins (oof maybe)

I think it should be possible to set the value to 50th percentile but also apply a 2 or 3x multiple to that so you can
1) be (more) confident the value you plucked from recent is within a normal-ish bound
2) juice it to move to the front of the list