### PR TITLE
don't throw in token bridge lookup

### DIFF
--- a/connect/src/routes/tokenBridge/automatic.ts
+++ b/connect/src/routes/tokenBridge/automatic.ts
@@ -89,7 +89,12 @@ export class AutomaticTokenBridgeRoute<N extends Network>
     fromChain: ChainContext<N>,
     toChain: ChainContext<N>,
   ): Promise<TokenId[]> {
-    return [await TokenTransfer.lookupDestinationToken(fromChain, toChain, sourceToken)];
+    try {
+      return [await TokenTransfer.lookupDestinationToken(fromChain, toChain, sourceToken)];
+    } catch (e) {
+      console.error(`Failed to get destination token: ${e}`);
+      return [];
+    }
   }
 
   static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {

--- a/connect/src/routes/tokenBridge/manual.ts
+++ b/connect/src/routes/tokenBridge/manual.ts
@@ -79,7 +79,12 @@ export class TokenBridgeRoute<N extends Network>
     fromChain: ChainContext<N>,
     toChain: ChainContext<N>,
   ): Promise<TokenId[]> {
-    return [await TokenTransfer.lookupDestinationToken(fromChain, toChain, sourceToken)];
+    try {
+      return [await TokenTransfer.lookupDestinationToken(fromChain, toChain, sourceToken)];
+    } catch (e) {
+      console.error(`Failed to get destination token: ${e}`);
+      return [];
+    }
   }
 
   static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {


### PR DESCRIPTION
prevents a throw that happens [here](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/main/platforms/evm/protocols/tokenBridge/src/tokenBridge.ts#L94) from crashing routes

really this should return something like a `Result` with either `Some(token)` or `None` instead of throwing... but this will do for now :-)