### PR TITLE
Expose generic types on RouteConstructor

### DIFF
--- a/connect/src/routes/resolver.ts
+++ b/connect/src/routes/resolver.ts
@@ -14,10 +14,10 @@ import type { Options, Receipt, ValidatedTransferParams } from "./types.js";
 
 export class RouteResolver<N extends Network> {
   wh: Wormhole<N>;
-  routeConstructors: RouteConstructor[];
+  routeConstructors: RouteConstructor<N>[];
   inputTokenList?: TokenId[];
 
-  constructor(wh: Wormhole<N>, routeConstructors: RouteConstructor[]) {
+  constructor(wh: Wormhole<N>, routeConstructors: RouteConstructor<N>[]) {
     this.wh = wh;
     this.routeConstructors = routeConstructors;
   }

--- a/connect/src/routes/resolver.ts
+++ b/connect/src/routes/resolver.ts
@@ -14,10 +14,10 @@ import type { Options, Receipt, ValidatedTransferParams } from "./types.js";
 
 export class RouteResolver<N extends Network> {
   wh: Wormhole<N>;
-  routeConstructors: RouteConstructor<N>[];
+  routeConstructors: RouteConstructor[];
   inputTokenList?: TokenId[];
 
-  constructor(wh: Wormhole<N>, routeConstructors: RouteConstructor<N>[]) {
+  constructor(wh: Wormhole<N>, routeConstructors: RouteConstructor[]) {
     this.wh = wh;
     this.routeConstructors = routeConstructors;
   }

--- a/connect/src/routes/route.ts
+++ b/connect/src/routes/route.ts
@@ -66,8 +66,8 @@ export interface RouteMeta {
   source?: string;
 }
 
-export interface RouteConstructor<N extends Network = Network, OP extends Options = Options> {
-  new(wh: Wormhole<N>, request: RouteTransferRequest<N>): Route<N, OP>;
+export interface RouteConstructor<OP extends Options = Options> {
+  new<N extends Network>(wh: Wormhole<N>, request: RouteTransferRequest<N>): Route<N, OP>;
   /**  Details about the route provided by the implementation */
   readonly meta: RouteMeta;
   /** get the list of networks this route supports */

--- a/connect/src/routes/route.ts
+++ b/connect/src/routes/route.ts
@@ -66,8 +66,8 @@ export interface RouteMeta {
   source?: string;
 }
 
-export interface RouteConstructor {
-  new <N extends Network>(wh: Wormhole<N>, request: RouteTransferRequest<N>): Route<N>;
+export interface RouteConstructor<N extends Network = Network, OP extends Options = Options> {
+  new(wh: Wormhole<N>, request: RouteTransferRequest<N>): Route<N, OP>;
   /**  Details about the route provided by the implementation */
   readonly meta: RouteMeta;
   /** get the list of networks this route supports */


### PR DESCRIPTION
This is required for proper typing in Connect SDKv2 migration 🤓 