### PR TITLE
AutomaticTokenBridge gas dropoff percentage of max change and decimal…

### DIFF
--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -658,7 +658,18 @@ export namespace TokenTransfer {
       dstDecimals,
     );
 
-    const dstNativeGasAmountRequested = transfer.nativeGas ?? 0n;
+    // nativeGas is in source chain decimals
+    const srcNativeGasAmountRequested = transfer.nativeGas ?? 0n;
+    // convert to destination chain decimals
+    const dstNativeGasAmountRequested = amount.units(
+      amount.scale(
+        amount.truncate(
+          amount.fromBaseUnits(srcNativeGasAmountRequested, srcDecimals),
+          TokenTransfer.MAX_DECIMALS,
+        ),
+        dstDecimals,
+      ),
+    );
 
     // The expected destination gas can be pulled from the destination token bridge
     let destinationNativeGas = 0n;


### PR DESCRIPTION
… scaling fix

Previously the AutomaticTokenBridge route calculated the gas dropoff amount as a percentage of the input amount. However this has been changed to be a percentage of the maxSwapAmount as it's an easier to use interface for users of the library (e.g. Connect).

Also fixed an issue where the native gas wasn't scaled correctly when the source and destination chains have different decimals for the input token.