### PR TITLE
connect: Added TransferQuoteWarning interface

### DIFF
--- a/connect/src/types.ts
+++ b/connect/src/types.ts
@@ -154,4 +154,12 @@ export interface TransferQuote {
   // this will contain the amount of native gas that is to be minted
   // on the destination chain given the current swap rates
   destinationNativeGas?: bigint;
+  // If the transfer being quoted has any warnings
+  // such as high slippage or a delay, they will be included here
+  warnings?: TransferQuoteWarning[];
+}
+
+export interface TransferQuoteWarning {
+  message: string;
+  url?: string;
 }


### PR DESCRIPTION
Useful for routes to return warning messages in the TransferQuote (e.g. high slippage, governor / rate limit delay, etc.).