### PR TITLE
Manual resume

### DIFF
--- a/connect/src/protocols/cctp/cctpTransfer.ts
+++ b/connect/src/protocols/cctp/cctpTransfer.ts
@@ -209,7 +209,7 @@ export class CircleTransfer<N extends Network = Network>
   }
 
   // init from source tx hash
-  static async fromTransaction<N extends Network>(
+  private static async fromTransaction<N extends Network>(
     wh: Wormhole<N>,
     from: TransactionId,
     timeout: number,

--- a/connect/src/protocols/cctp/cctpTransfer.ts
+++ b/connect/src/protocols/cctp/cctpTransfer.ts
@@ -209,7 +209,7 @@ export class CircleTransfer<N extends Network = Network>
   }
 
   // init from source tx hash
-  private static async fromTransaction<N extends Network>(
+  static async fromTransaction<N extends Network>(
     wh: Wormhole<N>,
     from: TransactionId,
     timeout: number,

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -192,7 +192,7 @@ export class TokenTransfer<N extends Network = Network>
     return tt;
   }
 
-  private static async fromTransaction<N extends Network>(
+  static async fromTransaction<N extends Network>(
     wh: Wormhole<N>,
     from: TransactionId,
     timeout: number,

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -405,10 +405,8 @@ export namespace TokenTransfer {
         throw new Error('no');
       }
 
-      const ben = wh.getChain(receipt.attestation.attestation.payload.to.chain);
-
       let isComplete = await TokenTransfer.isTransferComplete(
-        ben,
+        wh.getChain(receipt.attestation.attestation.payload.to.chain),
         receipt.attestation.attestation as TokenTransfer.VAA,
       );
 

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -343,13 +343,11 @@ export namespace TokenTransfer {
     receipt: TokenTransfer.TransferReceipt<SC, DC>,
     timeout: number = DEFAULT_TASK_TIMEOUT,
     fromChain?: ChainContext<N, SC>,
-    toChain?: ChainContext<N, DC>,
   ): AsyncGenerator<TokenTransfer.TransferReceipt<SC, DC>> {
     const start = Date.now();
     const leftover = (start: number, max: number) => Math.max(max - (Date.now() - start), 0);
 
     fromChain = fromChain ?? wh.getChain(receipt.from);
-    toChain = toChain ?? wh.getChain(receipt.to);
 
     // Check the source chain for initiation transaction
     // and capture the message id
@@ -403,8 +401,10 @@ export namespace TokenTransfer {
     if (isAttested(receipt) || isRedeemed(receipt)) {
       if (!receipt.attestation.attestation) throw "Signed Attestation required to check for redeem";
 
+      const ben = wh.getChain(receipt.attestation.attestation.payload.to.chain);
+
       let isComplete = await TokenTransfer.isTransferComplete(
-        toChain,
+        ben,
         receipt.attestation.attestation as TokenTransfer.VAA,
       );
 

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -402,7 +402,7 @@ export namespace TokenTransfer {
       if (!receipt.attestation.attestation) throw "Signed Attestation required to check for redeem";
 
       if (receipt.attestation.attestation.payloadName === 'AttestMeta') {
-        throw new Error('no');
+        throw new Error('Unable to track an AttestMeta receipt');
       }
 
       let isComplete = await TokenTransfer.isTransferComplete(

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -401,6 +401,10 @@ export namespace TokenTransfer {
     if (isAttested(receipt) || isRedeemed(receipt)) {
       if (!receipt.attestation.attestation) throw "Signed Attestation required to check for redeem";
 
+      if (receipt.attestation.attestation.payloadName === 'AttestMeta') {
+        throw new Error('no');
+      }
+
       const ben = wh.getChain(receipt.attestation.attestation.payload.to.chain);
 
       let isComplete = await TokenTransfer.isTransferComplete(

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -343,6 +343,7 @@ export namespace TokenTransfer {
     receipt: TokenTransfer.TransferReceipt<SC, DC>,
     timeout: number = DEFAULT_TASK_TIMEOUT,
     fromChain?: ChainContext<N, SC>,
+    toChain?: ChainContext<N, DC>,
   ): AsyncGenerator<TokenTransfer.TransferReceipt<SC, DC>> {
     const start = Date.now();
     const leftover = (start: number, max: number) => Math.max(max - (Date.now() - start), 0);
@@ -406,7 +407,7 @@ export namespace TokenTransfer {
       }
 
       let isComplete = await TokenTransfer.isTransferComplete(
-        wh.getChain(receipt.attestation.attestation.payload.to.chain),
+        toChain ?? wh.getChain(receipt.attestation.attestation.payload.to.chain),
         receipt.attestation.attestation as TokenTransfer.VAA,
       );
 

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -192,7 +192,7 @@ export class TokenTransfer<N extends Network = Network>
     return tt;
   }
 
-  static async fromTransaction<N extends Network>(
+  private static async fromTransaction<N extends Network>(
     wh: Wormhole<N>,
     from: TransactionId,
     timeout: number,

--- a/connect/src/routes/cctp/manual.ts
+++ b/connect/src/routes/cctp/manual.ts
@@ -187,7 +187,7 @@ export class CCTPRoute<N extends Network>
   }
 
   async resume(txid: TransactionId): Promise<R> {
-    const xfer = await CircleTransfer.fromTransaction(this.wh, txid, 10 * 1000);
+    const xfer = await CircleTransfer.from(this.wh, txid, 10 * 1000);
     return CircleTransfer.getReceipt(xfer);
   }
 

--- a/connect/src/routes/cctp/manual.ts
+++ b/connect/src/routes/cctp/manual.ts
@@ -6,6 +6,7 @@ import type {
   CircleTransferDetails,
   Signer,
   TokenId,
+  TransactionId,
 } from "@wormhole-foundation/sdk-definitions";
 import { CircleBridge, isSameToken } from "@wormhole-foundation/sdk-definitions";
 import { signSendWait } from "../../common.js";
@@ -183,6 +184,11 @@ export class CCTPRoute<N extends Network>
       //
       return receipt;
     }
+  }
+
+  async resume(txid: TransactionId): Promise<R> {
+    const xfer = await CircleTransfer.fromTransaction(this.wh, txid, 60 * 1000);
+    return CircleTransfer.getReceipt(xfer);
   }
 
   public override async *track(receipt: R, timeout?: number) {

--- a/connect/src/routes/cctp/manual.ts
+++ b/connect/src/routes/cctp/manual.ts
@@ -187,7 +187,7 @@ export class CCTPRoute<N extends Network>
   }
 
   async resume(txid: TransactionId): Promise<R> {
-    const xfer = await CircleTransfer.fromTransaction(this.wh, txid, 60 * 1000);
+    const xfer = await CircleTransfer.fromTransaction(this.wh, txid, 10 * 1000);
     return CircleTransfer.getReceipt(xfer);
   }
 

--- a/connect/src/routes/cctp/manual.ts
+++ b/connect/src/routes/cctp/manual.ts
@@ -170,7 +170,7 @@ export class CCTPRoute<N extends Network>
       const { message, attestation } = att;
       if (!attestation) throw new Error(`No Circle attestation for ${id}`);
 
-      const toChain = await this.wh.getChain(receipt.to);
+      const toChain = this.wh.getChain(receipt.to);
       const cb = await toChain.getCircleBridge();
       const xfer = cb.redeem(message.payload.mintRecipient, message, attestation);
       const dstTxids = await signSendWait<N, Chain>(toChain, xfer, signer);

--- a/connect/src/routes/route.ts
+++ b/connect/src/routes/route.ts
@@ -1,5 +1,5 @@
 import type { Chain, Network } from "@wormhole-foundation/sdk-base";
-import type { ChainContext, Signer, TokenId, TxHash } from "@wormhole-foundation/sdk-definitions";
+import type { ChainContext, Signer, TokenId, TransactionId } from "@wormhole-foundation/sdk-definitions";
 import type { Wormhole } from "../wormhole.js";
 import type { RouteTransferRequest } from "./request.js";
 import type {
@@ -130,7 +130,7 @@ export abstract class ManualRoute<
   NATIVE_GAS_DROPOFF_SUPPORTED = false;
   IS_AUTOMATIC = false;
   public abstract complete(sender: Signer, receipt: R): Promise<R>;
-  public abstract resume(sourceChain: Chain, sourceTx: TxHash): Promise<R>;
+  public abstract resume(tx: TransactionId): Promise<R>;
 }
 
 export function isManual<N extends Network>(route: Route<N>): route is ManualRoute<N> {

--- a/connect/src/routes/route.ts
+++ b/connect/src/routes/route.ts
@@ -1,5 +1,5 @@
 import type { Chain, Network } from "@wormhole-foundation/sdk-base";
-import type { ChainContext, Signer, TokenId } from "@wormhole-foundation/sdk-definitions";
+import type { ChainContext, Signer, TokenId, TxHash } from "@wormhole-foundation/sdk-definitions";
 import type { Wormhole } from "../wormhole.js";
 import type { RouteTransferRequest } from "./request.js";
 import type {
@@ -130,6 +130,7 @@ export abstract class ManualRoute<
   NATIVE_GAS_DROPOFF_SUPPORTED = false;
   IS_AUTOMATIC = false;
   public abstract complete(sender: Signer, receipt: R): Promise<R>;
+  public abstract resume(sourceChain: Chain, sourceTx: TxHash): Promise<R>;
 }
 
 export function isManual<N extends Network>(route: Route<N>): route is ManualRoute<N> {

--- a/connect/src/routes/tokenBridge/manual.ts
+++ b/connect/src/routes/tokenBridge/manual.ts
@@ -168,6 +168,15 @@ export class TokenBridgeRoute<N extends Network>
       destinationTxs: dstTxIds,
     };
   }
+  
+  /*
+  async resume(sourceChain: Chain, sourceTx: string): Promise<R> {
+    const partialReceipt: SourceInitiatedTransferReceipt<typeof sourceChain> = {
+      from: sourceChain,
+      state: TransferState.SourceInitiated,
+    }
+  }
+  */
 
   public override async *track(receipt: R, timeout?: number) {
     yield* TokenTransfer.track(this.wh, receipt, timeout);

--- a/connect/src/routes/tokenBridge/manual.ts
+++ b/connect/src/routes/tokenBridge/manual.ts
@@ -6,6 +6,7 @@ import type {
   Signer,
   TokenId,
   TokenTransferDetails,
+  TransactionId,
 } from "@wormhole-foundation/sdk-definitions";
 import { TokenTransfer } from "../../protocols/tokenBridge/tokenTransfer.js";
 import type {
@@ -170,19 +171,19 @@ export class TokenBridgeRoute<N extends Network>
     };
   }
   
-  async resume(fromChain: Chain, txid: string): Promise<R> {
-    const attestation = await TokenTransfer.getTransferVaa(this.wh, txid);
-    const id = await TokenTransfer.getTransferMessage(this.wh.getChain(fromChain), txid);
+  async resume(tx: TransactionId): Promise<R> {
+    const attestation = await TokenTransfer.getTransferVaa(this.wh, tx.txid);
+    const id = await TokenTransfer.getTransferMessage(this.wh.getChain(tx.chain), tx.txid);
 
     return {
-      from: fromChain,
+      from: tx.chain,
       to: attestation.payload.to.chain,
       state: TransferState.Attested,
       attestation: {
         attestation, id
       },
-      originTxs: [{ chain: fromChain, txid }],
-    } satisfies AttestedTransferReceipt<TokenTransfer.AttestationReceipt, typeof fromChain>
+      originTxs: [{ chain: tx.chain, txid: tx.txid }],
+    } satisfies AttestedTransferReceipt<TokenTransfer.AttestationReceipt, typeof tx.chain>
   }
 
   public override async *track(receipt: R, timeout?: number) {

--- a/connect/src/routes/tokenBridge/manual.ts
+++ b/connect/src/routes/tokenBridge/manual.ts
@@ -11,7 +11,6 @@ import type {
 import { TokenTransfer } from "../../protocols/tokenBridge/tokenTransfer.js";
 import type {
   AttestationReceipt,
-  AttestedTransferReceipt,
   SourceInitiatedTransferReceipt,
   TransferReceipt,
 } from "../../types.js";
@@ -171,19 +170,9 @@ export class TokenBridgeRoute<N extends Network>
     };
   }
   
-  async resume(tx: TransactionId): Promise<R> {
-    const attestation = await TokenTransfer.getTransferVaa(this.wh, tx.txid);
-    const id = await TokenTransfer.getTransferMessage(this.wh.getChain(tx.chain), tx.txid);
-
-    return {
-      from: tx.chain,
-      to: attestation.payload.to.chain,
-      state: TransferState.Attested,
-      attestation: {
-        attestation, id
-      },
-      originTxs: [{ chain: tx.chain, txid: tx.txid }],
-    } satisfies AttestedTransferReceipt<TokenTransfer.AttestationReceipt, typeof tx.chain>
+  async resume(txid: TransactionId): Promise<R> {
+    const xfer = await TokenTransfer.fromTransaction(this.wh, txid, 10 * 1000);
+    return TokenTransfer.getReceipt(xfer);
   }
 
   public override async *track(receipt: R, timeout?: number) {

--- a/connect/src/routes/tokenBridge/manual.ts
+++ b/connect/src/routes/tokenBridge/manual.ts
@@ -171,7 +171,7 @@ export class TokenBridgeRoute<N extends Network>
   }
   
   async resume(txid: TransactionId): Promise<R> {
-    const xfer = await TokenTransfer.fromTransaction(this.wh, txid, 10 * 1000);
+    const xfer = await TokenTransfer.from(this.wh, txid, 10 * 1000);
     return TokenTransfer.getReceipt(xfer);
   }
 


### PR DESCRIPTION
This adds a required `resume` method to `ManualRoute`, which takes a `TransactionId` (combination of chain + hash) and returns a `Receipt`.