### PR TITLE
Swallow Circle attestation error

### DIFF
--- a/connect/src/protocols/cctp/cctpTransfer.ts
+++ b/connect/src/protocols/cctp/cctpTransfer.ts
@@ -221,7 +221,16 @@ export class CircleTransfer<N extends Network = Network>
     // First try to parse out a WormholeMessage
     // If we get one or more, we assume its a Wormhole attested
     // transfer
-    const msgIds: WormholeMessageId[] = await fromChain.parseTransaction(txid);
+    let msgIds: WormholeMessageId[] = [];
+    try {
+      msgIds = await fromChain.parseTransaction(txid);
+    } catch (e: any) {
+      if (e.message.includes('no bridge messages found')) {
+        // This means it's a Circle attestation; swallow
+      } else {
+        throw e
+      }
+    }
 
     // If we found a VAA message, use it
     let ct: CircleTransfer<N>;


### PR DESCRIPTION
This function tries to determine whether a CCTP transfer uses a Wormhole or Circle attestation, but there is an error thrown downstream that indicates it's not a Wormhole attestation which this function just propagates. This diff catches that error and lets `msgIds` remain empty so the rest of the function works.