### PR TITLE
fix: update examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,8 @@
 1) git clone this repo and rebuild then cd to this directory
 
 ```sh
-git clone  https://github.com/wormhole-foundation/connect-sdk.git
+git clone  https://github.com/wormhole-foundation/wormhole-sdk-ts.git
+cd wormhole-sdk-ts
 npm install
 npm run build
 cd examples


### PR DESCRIPTION
The existing README was targeted for `connect-sdk`, updated it for `wormhole-sdk-ts`