### PR TITLE
connect: Added InReview transfer state, governor warnings and fixes

### DIFF
--- a/connect/src/index.ts
+++ b/connect/src/index.ts
@@ -2,6 +2,7 @@ export * from "./wormhole.js";
 export * from "./config.js";
 export * from "./common.js";
 export * from "./types.js";
+export * from "./warnings.js";
 
 export * from "./protocols/index.js";
 

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -1,5 +1,5 @@
 import type { Chain, Network } from "@wormhole-foundation/sdk-base";
-import { amount, encoding, toChain as toChainName } from "@wormhole-foundation/sdk-base";
+import { amount, encoding, finality, toChain as toChainName } from "@wormhole-foundation/sdk-base";
 import type {
   AttestationId,
   AutomaticTokenBridge,
@@ -701,11 +701,13 @@ export namespace TokenTransfer {
     const dstDecimals = await dstChain.getDecimals(dstToken.address);
     const dstAmountReceivable = amount.scale(srcAmountTruncated, dstDecimals);
 
+    const eta = finality.estimateFinalityTime(srcChain.chain);
     if (!transfer.automatic) {
       return {
         sourceToken: { token: srcToken, amount: amount.units(srcAmountTruncated) },
         destinationToken: { token: dstToken, amount: amount.units(dstAmountReceivable) },
         warnings: warnings.length > 0 ? warnings : undefined,
+        eta,
       };
     }
 
@@ -796,6 +798,7 @@ export namespace TokenTransfer {
       relayFee: { token: srcToken, amount: fee },
       destinationNativeGas,
       warnings: warnings.length > 0 ? warnings : undefined,
+      eta,
     };
   }
 

--- a/connect/src/routes/portico/automatic.ts
+++ b/connect/src/routes/portico/automatic.ts
@@ -36,6 +36,7 @@ import {
 } from "./../../index.js";
 import type { ChainAddress } from "@wormhole-foundation/sdk-definitions";
 import type { RouteTransferRequest } from "../request.js";
+import { finality } from "@wormhole-foundation/sdk-base";
 
 export const SLIPPAGE_BPS = 15n; // 0.15%
 export const BPS_PER_HUNDRED_PERCENT = 10000n;
@@ -255,6 +256,7 @@ export class AutomaticPorticoRoute<N extends Network>
             token: params.normalizedParams.destinationToken,
             amount: fee,
           },
+          eta: finality.estimateFinalityTime(request.fromChain.chain),
         },
         params,
         details,

--- a/connect/src/routes/request.ts
+++ b/connect/src/routes/request.ts
@@ -68,6 +68,8 @@ export class RouteTransferRequest<N extends Network> {
       dq.warnings = [...quote.warnings];
     }
 
+    dq.eta = quote.eta;
+
     if (details) {
       dq.details = details;
     }

--- a/connect/src/routes/request.ts
+++ b/connect/src/routes/request.ts
@@ -64,6 +64,10 @@ export class RouteTransferRequest<N extends Network> {
       dq.destinationNativeGas = amount.fromBaseUnits(quote.destinationNativeGas, dstDecimals);
     }
 
+    if (quote.warnings && quote.warnings.length > 0) {
+      dq.warnings = [...quote.warnings];
+    }
+
     if (details) {
       dq.details = details;
     }

--- a/connect/src/routes/types.ts
+++ b/connect/src/routes/types.ts
@@ -75,6 +75,9 @@ export type Quote<
   // If the transfer being quoted has any warnings
   // such as high slippage or a delay, they will be included here
   warnings?: QuoteWarning[];
+
+  // Estimated time to completion in milliseconds
+  eta?: number;
 };
 
 export type QuoteError = {

--- a/connect/src/routes/types.ts
+++ b/connect/src/routes/types.ts
@@ -1,6 +1,7 @@
 import type { TokenId } from "@wormhole-foundation/sdk-definitions";
-import type { AttestationReceipt, QuoteWarning, TransferReceipt } from "../types.js";
+import type { AttestationReceipt, TransferReceipt } from "../types.js";
 import type { amount } from "@wormhole-foundation/sdk-base";
+import type { QuoteWarning } from "../warnings.js";
 
 // Extend Options to provide custom options
 // to use for the transfer

--- a/connect/src/types.ts
+++ b/connect/src/types.ts
@@ -193,4 +193,6 @@ export interface TransferQuote {
   // If the transfer being quoted has any warnings
   // such as high slippage or a delay, they will be included here
   warnings?: QuoteWarning[];
+  // Estimated time to completion in milliseconds
+  eta?: number;
 }

--- a/connect/src/warnings.ts
+++ b/connect/src/warnings.ts
@@ -1,0 +1,11 @@
+export type DestinationCapacityWarning = {
+  type: "DestinationCapacityWarning";
+  delayDurationSec?: number;
+};
+
+export type GovernorLimitWarning = {
+  type: "GovernorLimitWarning";
+  reason: "ExceedsRemainingNotional" | "ExceedsLargeTransferLimit";
+};
+
+export type QuoteWarning = DestinationCapacityWarning | GovernorLimitWarning;

--- a/connect/src/whscan-api.ts
+++ b/connect/src/whscan-api.ts
@@ -422,18 +422,11 @@ export async function getGovernorLimits(rpcUrl: string): Promise<GovernorLimits 
   return null;
 }
 
-// TODO: returning bool or null is asking for trouble
-export async function getIsVaaEnqueued(
-  rpcUrl: string,
-  whm: WormholeMessageId,
-): Promise<boolean | null> {
+export async function getIsVaaEnqueued(rpcUrl: string, whm: WormholeMessageId): Promise<boolean> {
   const { chain, emitter, sequence } = whm;
   const chainId = toChainId(chain);
   const emitterAddress = emitter.toUniversalAddress().toString();
   const url = `${rpcUrl}/v1/governor/is_vaa_enqueued/${chainId}/${emitterAddress}/${sequence}`;
-  try {
-    const response = await axios.get<{ isEnqueued: boolean }>(url);
-    return response.data.isEnqueued;
-  } catch {}
-  return null;
+  const response = await axios.get<{ isEnqueued: boolean }>(url);
+  return response.data.isEnqueued;
 }

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -32,6 +32,7 @@ import { RouteResolver } from "./routes/resolver.js";
 import { retry } from "./tasks.js";
 import type { TransactionStatus } from "./whscan-api.js";
 import {
+  getIsVaaEnqueued,
   getTransactionStatusWithRetry,
   getTxsByAddress,
   getVaaByTxHashWithRetry,
@@ -193,7 +194,7 @@ export class Wormhole<N extends Network> {
   /**
    * Gets the TokenId for a token representation on any chain
    *  These are the Wormhole wrapped token addresses, not necessarily
-   *  the cannonical version of that token
+   *  the canonical version of that token
    *
    * @param chain The chain name to get the wrapped token address
    * @param tokenId The Token ID (chain/address) of the original token
@@ -209,7 +210,7 @@ export class Wormhole<N extends Network> {
   /**
    *  Taking the original TokenId for some wrapped token chain
    *  These are the Wormhole wrapped token addresses, not necessarily
-   *  the cannonical version of that token
+   *  the canonical version of that token
    *
    * @param tokenId The Token ID of the token we're looking up the original asset for
    * @returns The Original TokenId corresponding to the token id passed,
@@ -300,6 +301,15 @@ export class Wormhole<N extends Network> {
   }
 
   /**
+   * Gets if the token bridge transfer VAA has been enqueued by the Governor.
+   * @param id The WormholeMessageId corresponding to the token bridge transfer VAA to check
+   * @returns True if the transfer has been enqueued, false otherwise
+   */
+  async getIsVaaEnqueued(id: WormholeMessageId): Promise<boolean> {
+    return await getIsVaaEnqueued(this.config.api, id);
+  }
+
+  /**
    * Gets the CircleAttestation corresponding to the message hash logged in the transfer transaction.
    * @param msgHash  The keccak256 hash of the message emitted by the circle contract
    * @param timeout The total amount of time to wait for the VAA to be available
@@ -351,7 +361,7 @@ export class Wormhole<N extends Network> {
   }
 
   /**
-   * Parse an address from its canonincal string format to a NativeAddress
+   * Parse an address from its canonical string format to a NativeAddress
    *
    * @param chain The chain the address is for
    * @param address The address in canonical string format

--- a/core/base/src/constants/finality.ts
+++ b/core/base/src/constants/finality.ts
@@ -176,3 +176,18 @@ export function consistencyLevelToBlock(
       throw new Error("Only Ethereum safe is supported for now");
   }
 }
+
+/**
+ * Estimates the time required for a transaction to be considered "final"
+ * @param chain The chain to estimate finality time for
+ * @returns The estimated time in milliseconds
+ */
+export function estimateFinalityTime(chain: Chain): number {
+  const finality = finalityThreshold.get(chain);
+  if (finality === undefined) throw new Error("Cannot find finality for " + chain);
+
+  const time = blockTime.get(chain);
+  if (time === undefined) throw new Error("Cannot find block time for " + chain);
+
+  return finality * time;
+}


### PR DESCRIPTION
The InReview transfer state is currently set when a token bridge transfer is enqueued in the Governor.

Added Governor warnings to token bridge quotes.

Fixed an issue where the token price wasn't being looked up by its origin chain.