### PR TITLE
fix: throws an `Error` object instead of plain string in `getTokenMap`

### DIFF
--- a/core/base/src/constants/tokens/index.ts
+++ b/core/base/src/constants/tokens/index.ts
@@ -24,7 +24,7 @@ export function getTokenMap<N extends Network, C extends Chain>(
     return Object.fromEntries(chainTokens!.map(([key, token]) => [key, { ...token, chain, key }]));
   }
 
-  throw "Unsupported network: " + network;
+  throw new Error("Unsupported network: " + network);
 }
 
 // The token that represents the native gas token on a given chain


### PR DESCRIPTION
This ensures a stack trace accompanies the error thrown, improving devex.