### PR TITLE
tokenBridge protocol: added native and universal token address conversions

### DIFF
--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -39,6 +39,7 @@ import {
   getVaaBytesWithRetry,
   getVaaWithRetry,
 } from "./whscan-api.js";
+import { UniversalAddress } from "@wormhole-foundation/sdk-definitions";
 
 type PlatformMap<N extends Network, P extends Platform = Platform> = Map<P, PlatformContext<N, P>>;
 type ChainMap<N extends Network, C extends Chain = Chain> = Map<C, ChainContext<N, C>>;
@@ -220,6 +221,38 @@ export class Wormhole<N extends Network> {
     const ctx = this.getChain(token.chain);
     const tb = await ctx.getTokenBridge();
     return await tb.getOriginalAsset(token.address);
+  }
+
+  /**
+   * Returns the UniversalAddress of the token. This may require fetching on-chain data.
+   * @param chain The chain to get the UniversalAddress for
+   * @param token The address to get the UniversalAddress for
+   * @returns The UniversalAddress of the token
+   */
+  async getTokenUniversalAddress<C extends Chain>(
+    chain: C,
+    token: NativeAddress<C>,
+  ): Promise<UniversalAddress> {
+    const ctx = this.getChain(chain);
+    const tb = await ctx.getTokenBridge();
+    return await tb.getTokenUniversalAddress(token);
+  }
+
+  /**
+   * Returns the native address of the token. This may require fetching on-chain data.
+   * @param chain The chain to get the native address for
+   * @param originChain The chain the token is from / native to
+   * @param token The address to get the native address for
+   * @returns The native address of the token
+   */
+  async getTokenNativeAddress<C extends Chain>(
+    chain: C,
+    originChain: Chain,
+    token: UniversalAddress,
+  ): Promise<NativeAddress<C>> {
+    const ctx = this.getChain(chain);
+    const tb = await ctx.getTokenBridge();
+    return await tb.getTokenNativeAddress(originChain, token);
   }
 
   /**

--- a/core/definitions/src/protocols/tokenBridge/tokenBridge.ts
+++ b/core/definitions/src/protocols/tokenBridge/tokenBridge.ts
@@ -1,7 +1,7 @@
 import type { Chain, Network } from "@wormhole-foundation/sdk-base";
 import { lazyInstantiate } from "@wormhole-foundation/sdk-base";
-import type { AccountAddress, ChainAddress } from "../../address.js";
-import { UniversalAddress } from "../../universalAddress.js";
+import type { AccountAddress, ChainAddress, NativeAddress } from "../../address.js";
+import type { UniversalAddress } from "../../universalAddress.js";
 import type { TokenAddress, TokenId } from "../../types.js";
 import type { UnsignedTransaction } from "../../unsignedTransaction.js";
 import type { ProtocolPayload, ProtocolVAA } from "./../../vaa/index.js";
@@ -135,19 +135,26 @@ export interface TokenBridge<N extends Network = Network, C extends Chain = Chai
    */
   getOriginalAsset(nativeAddress: TokenAddress<C>): Promise<TokenId<Chain>>;
   /**
-   * Returns the UniversalAddress of the token. This may require retrieving data on-chain.
+   * Returns the UniversalAddress of the token. This may require fetching on-chain data.
    *
-   * @param nativeAddress The address to get the UniversalAddress for
+   * @param token The address to get the UniversalAddress for
    * @returns The UniversalAddress of the token
    */
-  getTokenUniversalAddress(nativeAddress: TokenAddress<C>): Promise<UniversalAddress>;
+  getTokenUniversalAddress(token: NativeAddress<C>): Promise<UniversalAddress>;
+  /**
+   * Returns the native address of the token. This may require fetching on-chain data.
+   * @param originChain The chain the token is from / native to
+   * @param token The address to get the native address for
+   * @returns The native address of the token
+   */
+  getTokenNativeAddress(originChain: Chain, token: UniversalAddress): Promise<NativeAddress<C>>;
   /**
    * returns the wrapped version of the native asset
    *
    * @returns The address of the native gas token that has been wrapped
    * for use where the gas token is not possible to use (e.g. bridging)
    */
-  getWrappedNative(): Promise<TokenAddress<C>>;
+  getWrappedNative(): Promise<NativeAddress<C>>;
   /**
    * Check to see if a foreign token has a wrapped version
    *

--- a/core/definitions/src/testing/mocks/tokenBridge.ts
+++ b/core/definitions/src/testing/mocks/tokenBridge.ts
@@ -1,4 +1,4 @@
-import type { Network, Platform, PlatformToChains } from "@wormhole-foundation/sdk-base";
+import type { Chain, Network, Platform, PlatformToChains } from "@wormhole-foundation/sdk-base";
 import type {
   ChainAddress,
   NativeAddress,
@@ -20,7 +20,10 @@ export class MockTokenBridge<N extends Network, P extends Platform, C extends Pl
   getOriginalAsset(token: TokenAddress<C>): Promise<ChainAddress> {
     throw new Error("Method not implemented.");
   }
-  getTokenUniversalAddress(nativeAddress: TokenAddress<C>): Promise<UniversalAddress> {
+  getTokenUniversalAddress(token: NativeAddress<C>): Promise<UniversalAddress> {
+    throw new Error("Method not implemented.");
+  }
+  getTokenNativeAddress(originChain: Chain, token: UniversalAddress): Promise<NativeAddress<C>> {
     throw new Error("Method not implemented.");
   }
   hasWrappedAsset(original: ChainAddress): Promise<boolean> {

--- a/platforms/algorand/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/algorand/protocols/tokenBridge/src/tokenBridge.ts
@@ -146,12 +146,20 @@ export class AlgorandTokenBridge<N extends Network, C extends AlgorandChains>
     return { chain, address };
   }
 
-  async getTokenUniversalAddress(token: TokenAddress<C>): Promise<UniversalAddress> {
+  async getTokenUniversalAddress(token: NativeAddress<C>): Promise<UniversalAddress> {
     return new AlgorandAddress(token).toUniversalAddress();
+  }
+
+  async getTokenNativeAddress(
+    originChain: Chain,
+    token: UniversalAddress,
+  ): Promise<NativeAddress<C>> {
+    return new AlgorandAddress(token).toNative() as NativeAddress<C>;
   }
 
   // Returns the address of the native version of this asset
   async getWrappedAsset(token: TokenId<Chain>): Promise<NativeAddress<C>> {
+    if (isNative(token.address)) throw new Error("native asset cannot be a wrapped asset");
     const storageAccount = StorageLogicSig.forWrappedAsset(this.tokenBridgeAppId, token);
     const data = await StorageLogicSig.decodeLocalState(
       this.connection,

--- a/platforms/algorand/src/address.ts
+++ b/platforms/algorand/src/address.ts
@@ -8,7 +8,7 @@ import { _platform, safeBigIntToNumber } from "./types.js";
 export const AlgorandZeroAddress = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ";
 
 // Note: for ASA/App IDs we encode them as 8 bytes at the start of
-// the 32 byte adddress bytes.
+// the 32 byte address bytes.
 
 export class AlgorandAddress implements Address {
   static readonly byteSize = 32;

--- a/platforms/cosmwasm/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/cosmwasm/protocols/tokenBridge/src/tokenBridge.ts
@@ -1,5 +1,6 @@
 import type { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import type {
+  Chain,
   ChainAddress,
   ChainsConfig,
   Contracts,
@@ -125,8 +126,15 @@ export class CosmwasmTokenBridge<N extends Network, C extends CosmwasmChains>
     };
   }
 
-  async getTokenUniversalAddress(token: AnyCosmwasmAddress): Promise<UniversalAddress> {
+  async getTokenUniversalAddress(token: NativeAddress<C>): Promise<UniversalAddress> {
     return new CosmwasmAddress(token).toUniversalAddress();
+  }
+
+  async getTokenNativeAddress(
+    originChain: Chain,
+    token: UniversalAddress,
+  ): Promise<NativeAddress<C>> {
+    return new CosmwasmAddress(token).toNative() as NativeAddress<C>;
   }
 
   async isTransferCompleted(vaa: TokenBridge.TransferVAA): Promise<boolean> {

--- a/platforms/cosmwasm/src/gateway.ts
+++ b/platforms/cosmwasm/src/gateway.ts
@@ -12,6 +12,7 @@ import { CosmwasmChain } from "./chain.js";
 import { IBC_TRANSFER_PORT } from "./constants.js";
 import { CosmwasmPlatform } from "./platform.js";
 import type { CosmwasmChains } from "./types.js";
+import { isNative } from "@wormhole-foundation/sdk-connect";
 
 export class Gateway<N extends Network> extends CosmwasmChain<N, "Wormchain"> {
   static chain: "Wormchain" = "Wormchain";
@@ -25,6 +26,7 @@ export class Gateway<N extends Network> extends CosmwasmChain<N, "Wormchain"> {
 
   // Get the wrapped version of an asset created on wormchain
   async getWrappedAsset(token: TokenId): Promise<CosmwasmAddress> {
+    if (isNative(token.address)) throw new Error("native asset cannot be a wrapped asset");
     const tb = await this.getTokenBridge();
     const wrappedAsset = new CosmwasmAddress(await tb.getWrappedAsset(token));
 

--- a/platforms/evm/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/evm/protocols/tokenBridge/src/tokenBridge.ts
@@ -106,9 +106,16 @@ export class EvmTokenBridge<N extends Network, C extends EvmChains>
   }
 
   async getTokenUniversalAddress(
-    token: TokenAddress<C>,
+    token: NativeAddress<C>,
   ): Promise<UniversalAddress> {
     return new EvmAddress(token).toUniversalAddress();
+  }
+
+  async getTokenNativeAddress(
+    originChain: Chain,
+    token: UniversalAddress,
+  ): Promise<NativeAddress<C>> {
+    return new EvmAddress(token).toNative() as NativeAddress<C>;
   }
 
   async hasWrappedAsset(token: TokenId): Promise<boolean> {

--- a/platforms/solana/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/solana/protocols/tokenBridge/src/tokenBridge.ts
@@ -1,8 +1,10 @@
 import type {
+  Chain,
   ChainAddress,
   ChainId,
   ChainsConfig,
   Contracts,
+  NativeAddress,
   Network,
   Platform,
   TokenBridge,
@@ -157,7 +159,7 @@ export class SolanaTokenBridge<N extends Network, C extends SolanaChains>
 
       return {
         chain: toChain(meta.chain as ChainId),
-        address: new UniversalAddress(meta.tokenAddress),
+        address: new UniversalAddress(new Uint8Array(meta.tokenAddress)),
       };
     } catch (_) {
       throw ErrNotWrapped(token.toString());
@@ -165,9 +167,16 @@ export class SolanaTokenBridge<N extends Network, C extends SolanaChains>
   }
 
   async getTokenUniversalAddress(
-    token: AnySolanaAddress,
+    token: NativeAddress<C>,
   ): Promise<UniversalAddress> {
     return new SolanaAddress(token).toUniversalAddress();
+  }
+
+  async getTokenNativeAddress(
+    originChain: Chain,
+    token: UniversalAddress,
+  ): Promise<NativeAddress<C>> {
+    return new SolanaAddress(token).toNative() as NativeAddress<C>;
   }
 
   async hasWrappedAsset(token: TokenId): Promise<boolean> {

--- a/platforms/sui/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/sui/protocols/tokenBridge/src/tokenBridge.ts
@@ -29,7 +29,8 @@ import {
   toNative,
 } from "@wormhole-foundation/sdk-connect";
 
-import type { SuiAddress, SuiBuildOutput, SuiChains } from "@wormhole-foundation/sdk-sui";
+import type { SuiBuildOutput, SuiChains } from "@wormhole-foundation/sdk-sui";
+import { SuiAddress } from "@wormhole-foundation/sdk-sui";
 import {
   SuiPlatform,
   SuiUnsignedTransaction,
@@ -148,7 +149,7 @@ export class SuiTokenBridge<N extends Network, C extends SuiChains> implements T
     throw ErrNotWrapped(coinType);
   }
 
-  async getTokenUniversalAddress(token: TokenAddress<C>): Promise<UniversalAddress> {
+  async getTokenUniversalAddress(token: NativeAddress<C>): Promise<UniversalAddress> {
     let coinType = (token as SuiAddress).getCoinType();
     if (!isValidSuiType(coinType)) throw new Error(`Invalid Sui type: ${coinType}`);
 
@@ -190,11 +191,20 @@ export class SuiTokenBridge<N extends Network, C extends SuiChains> implements T
     }
 
     throw new Error(`Token of type ${coinType} is not a native asset`);
+  }
 
-    //// TODO: implement
-    //return new UniversalAddress(
-    //  Buffer.from("9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3", "hex"),
-    //);
+  async getTokenNativeAddress(
+    originChain: Chain,
+    token: UniversalAddress,
+  ): Promise<NativeAddress<C>> {
+    const address = await getTokenCoinType(
+      this.provider,
+      this.tokenBridgeObjectId,
+      token.toUint8Array(),
+      toChainId(originChain),
+    );
+    if (!address) throw new Error(`Token ${token.toString()} not found in token registry`);
+    return new SuiAddress(address) as NativeAddress<C>;
   }
 
   async hasWrappedAsset(token: TokenId): Promise<boolean> {


### PR DESCRIPTION
- UniversalAddress for *tokens* leaks token bridge implementation details.
- Users should only work with addresses in canonical form.
- Added getTokenUniversalAddress and getTokenNativeAddress to each platform’s token bridge protocol implementation.
- quoteTransfer and lookupDestinationToken now throw if they receive a universal address.
- Ensured lookupDestinationToken returns a TokenId with a native address.
- Updated handling for chains like Sui and Aptos to fetch on-chain data for address conversions.