### PR TITLE
cctp: gas drop-off fix

### DIFF
--- a/core/definitions/src/protocols/circleBridge/circleBridge.ts
+++ b/core/definitions/src/protocols/circleBridge/circleBridge.ts
@@ -187,4 +187,8 @@ export interface AutomaticCircleBridge<N extends Network = Network, C extends Ch
     amount: bigint,
     nativeGas?: bigint,
   ): AsyncGenerator<UnsignedTransaction<N, C>>;
+  /** Amount of native tokens a user would receive by swapping x amount of sending tokens */
+  nativeTokenAmount(amount: bigint): Promise<bigint>;
+  /** Maximum amount of sending tokens that can be swapped for native tokens */
+  maxSwapAmount(): Promise<bigint>;
 }

--- a/platforms/evm/protocols/cctp/src/automaticCircleBridge.ts
+++ b/platforms/evm/protocols/cctp/src/automaticCircleBridge.ts
@@ -163,4 +163,15 @@ export class EvmAutomaticCircleBridge<N extends Network, C extends EvmChains>
       parallelizable,
     );
   }
+
+  async nativeTokenAmount(amount: bigint): Promise<bigint> {
+    return await this.circleRelayer.calculateNativeSwapAmountOut(
+      this.tokenAddr,
+      amount,
+    );
+  }
+
+  async maxSwapAmount(): Promise<bigint> {
+    return await this.circleRelayer.calculateMaxSwapAmountIn(this.tokenAddr);
+  }
 }


### PR DESCRIPTION
- use wormhole circle relayer instead of token bridge relayer to compute max swap and gas drop-off amounts
- the connect interface specifies a percentage that is applied to the the max swap amount to get the gas drop-off amount