### PR TITLE
connect: Wormhole pass config to platform constructors

### DIFF
--- a/connect/src/protocols/cctp/cctpTransfer.ts
+++ b/connect/src/protocols/cctp/cctpTransfer.ts
@@ -1,5 +1,5 @@
 import type { Chain, Network } from "@wormhole-foundation/sdk-base";
-import { circle, encoding, toChain } from "@wormhole-foundation/sdk-base";
+import { circle, encoding, finality, toChain } from "@wormhole-foundation/sdk-base";
 import type {
   Attestation,
   AttestationId,
@@ -43,7 +43,6 @@ import {
 } from "../../types.js";
 import { Wormhole } from "../../wormhole.js";
 import type { WormholeTransfer } from "../wormholeTransfer.js";
-import { finality } from "@wormhole-foundation/sdk-base";
 
 export class CircleTransfer<N extends Network = Network>
   implements WormholeTransfer<CircleTransfer.Protocol>

--- a/connect/src/routes/portico/automatic.ts
+++ b/connect/src/routes/portico/automatic.ts
@@ -1,4 +1,4 @@
-import { filters } from "@wormhole-foundation/sdk-base";
+import { filters, finality } from "@wormhole-foundation/sdk-base";
 import type { StaticRouteMethods } from "../route.js";
 import { AutomaticRoute } from "../route.js";
 import type {
@@ -36,7 +36,6 @@ import {
 } from "./../../index.js";
 import type { ChainAddress } from "@wormhole-foundation/sdk-definitions";
 import type { RouteTransferRequest } from "../request.js";
-import { finality } from "@wormhole-foundation/sdk-base";
 
 export const SLIPPAGE_BPS = 15n; // 0.15%
 export const BPS_PER_HUNDRED_PERCENT = 10000n;

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -12,6 +12,7 @@ import type {
   TokenAddress,
   TokenId,
   TxHash,
+  UniversalAddress,
   WormholeMessageId,
   deserialize,
 } from "@wormhole-foundation/sdk-definitions";
@@ -39,7 +40,6 @@ import {
   getVaaBytesWithRetry,
   getVaaWithRetry,
 } from "./whscan-api.js";
-import { UniversalAddress } from "@wormhole-foundation/sdk-definitions";
 
 type PlatformMap<N extends Network, P extends Platform = Platform> = Map<P, PlatformContext<N, P>>;
 type ChainMap<N extends Network, C extends Chain = Chain> = Map<C, ChainContext<N, C>>;
@@ -58,7 +58,7 @@ export class Wormhole<N extends Network> {
     this._chains = new Map();
     this._platforms = new Map();
     for (const p of platforms) {
-      this._platforms.set(p._platform, new p(network));
+      this._platforms.set(p._platform, new p(network, this.config.chains));
     }
   }
 


### PR DESCRIPTION
We were not passing the config, which may contain overrides, to the platform constructors in the Wormhole class. This was causing the default RPCs to get used even if they were overridden in the config.