### PR TITLE
Make IS_AUTOMATIC & NATIVE_GAS_DROPOFF_SUPPORTED into static properties

### DIFF
--- a/connect/src/routes/cctp/automatic.ts
+++ b/connect/src/routes/cctp/automatic.ts
@@ -54,7 +54,7 @@ export class AutomaticCCTPRoute<N extends Network>
   extends AutomaticRoute<N, Op, Vp, R>
   implements StaticRouteMethods<typeof AutomaticCCTPRoute>
 {
-  NATIVE_GAS_DROPOFF_SUPPORTED = true;
+  static NATIVE_GAS_DROPOFF_SUPPORTED = true;
 
   static meta = {
     name: "AutomaticCCTP",

--- a/connect/src/routes/portico/automatic.ts
+++ b/connect/src/routes/portico/automatic.ts
@@ -72,7 +72,7 @@ export class AutomaticPorticoRoute<N extends Network>
   extends AutomaticRoute<N, OP, VP, R>
   implements StaticRouteMethods<typeof AutomaticPorticoRoute>
 {
-  NATIVE_GAS_DROPOFF_SUPPORTED = false;
+  static NATIVE_GAS_DROPOFF_SUPPORTED = false;
 
   static meta = {
     name: "AutomaticPortico",

--- a/connect/src/routes/tokenBridge/automatic.ts
+++ b/connect/src/routes/tokenBridge/automatic.ts
@@ -55,7 +55,7 @@ export class AutomaticTokenBridgeRoute<N extends Network>
   extends AutomaticRoute<N, Op, Vp, R>
   implements StaticRouteMethods<typeof AutomaticTokenBridgeRoute>
 {
-  NATIVE_GAS_DROPOFF_SUPPORTED = true;
+  static NATIVE_GAS_DROPOFF_SUPPORTED = true;
 
   static meta = {
     name: "AutomaticTokenBridge",


### PR DESCRIPTION
These should have been static to begin with. This change lets us reference them on the route constructor, before the route has been initialized. Helpful to clean up [this](https://github.com/wormhole-foundation/wormhole-connect/blob/development/wormhole-connect/src/routes/sdkv2/route.ts#L51-L64) where we don't have an instance of the route, only the constructor.