### PR TITLE
solana: added rpc-websockets dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-sdk",
-  "version": "0.7.3-beta.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-sdk",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "workspaces": [
         "core/base",
@@ -59,11 +59,11 @@
     },
     "connect": {
       "name": "@wormhole-foundation/sdk-connect",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-base": "0.10.0",
+        "@wormhole-foundation/sdk-definitions": "0.10.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -72,7 +72,7 @@
     },
     "core/base": {
       "name": "@wormhole-foundation/sdk-base",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3"
@@ -80,11 +80,11 @@
     },
     "core/definitions": {
       "name": "@wormhole-foundation/sdk-definitions",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-base": "0.10.0"
       }
     },
     "core/definitions/node_modules/@noble/curves": {
@@ -109,10 +109,10 @@
     },
     "core/icons": {
       "name": "@wormhole-foundation/sdk-icons",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-base": "0.10.0"
       },
       "devDependencies": {
         "tsx": "^4.7.0"
@@ -120,10 +120,10 @@
     },
     "examples": {
       "name": "@wormhole-foundation/connect-sdk-examples",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk": "0.10.0"
       },
       "devDependencies": {
         "dotenv": "^16.3.1",
@@ -7695,8 +7695,9 @@
       }
     },
     "node_modules/rpc-websockets": {
-      "version": "7.6.2",
-      "license": "LGPL-3.0-only",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.10.0.tgz",
+      "integrity": "sha512-cemZ6RiDtYZpPiBzYijdOrkQQzmBCmug0E9SdRH2gIUNT15ql4mwCYWIp0VnSZq6Qrw/JkGUygp4PrK1y9KfwQ==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "eventemitter3": "^4.0.7",
@@ -8902,10 +8903,10 @@
     },
     "platforms/algorand": {
       "name": "@wormhole-foundation/sdk-algorand",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -8914,11 +8915,11 @@
     },
     "platforms/algorand/protocols/core": {
       "name": "@wormhole-foundation/sdk-algorand-core",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-algorand": "0.10.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -8926,12 +8927,12 @@
     },
     "platforms/algorand/protocols/tokenBridge": {
       "name": "@wormhole-foundation/sdk-algorand-tokenbridge",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-algorand-core": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-algorand": "0.10.0",
+        "@wormhole-foundation/sdk-algorand-core": "0.10.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -8939,10 +8940,10 @@
     },
     "platforms/aptos": {
       "name": "@wormhole-foundation/sdk-aptos",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
         "aptos": "1.21.0"
       },
       "engines": {
@@ -8951,11 +8952,11 @@
     },
     "platforms/aptos/protocols/core": {
       "name": "@wormhole-foundation/sdk-aptos-core",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-aptos": "0.10.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -8963,11 +8964,11 @@
     },
     "platforms/aptos/protocols/tokenBridge": {
       "name": "@wormhole-foundation/sdk-aptos-tokenbridge",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-aptos": "0.10.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -8975,14 +8976,14 @@
     },
     "platforms/cosmwasm": {
       "name": "@wormhole-foundation/sdk-cosmwasm",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -8991,14 +8992,14 @@
     },
     "platforms/cosmwasm/protocols/core": {
       "name": "@wormhole-foundation/sdk-cosmwasm-core",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -9006,15 +9007,15 @@
     },
     "platforms/cosmwasm/protocols/ibc": {
       "name": "@wormhole-foundation/sdk-cosmwasm-ibc",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.10.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.10.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -9023,13 +9024,13 @@
     },
     "platforms/cosmwasm/protocols/tokenBridge": {
       "name": "@wormhole-foundation/sdk-cosmwasm-tokenbridge",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -9037,10 +9038,10 @@
     },
     "platforms/evm": {
       "name": "@wormhole-foundation/sdk-evm",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
         "ethers": "^6.5.1"
       },
       "devDependencies": {
@@ -9052,11 +9053,11 @@
     },
     "platforms/evm/protocols/cctp": {
       "name": "@wormhole-foundation/sdk-evm-cctp",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-evm": "0.10.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -9065,11 +9066,11 @@
     },
     "platforms/evm/protocols/core": {
       "name": "@wormhole-foundation/sdk-evm-core",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-evm": "0.10.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -9078,13 +9079,13 @@
     },
     "platforms/evm/protocols/portico": {
       "name": "@wormhole-foundation/sdk-evm-portico",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm-core": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-evm": "0.10.0",
+        "@wormhole-foundation/sdk-evm-core": "0.10.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.10.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -9093,12 +9094,12 @@
     },
     "platforms/evm/protocols/tokenBridge": {
       "name": "@wormhole-foundation/sdk-evm-tokenbridge",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm-core": "0.7.3-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-evm": "0.10.0",
+        "@wormhole-foundation/sdk-evm-core": "0.10.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -9107,14 +9108,15 @@
     },
     "platforms/solana": {
       "name": "@wormhole-foundation/sdk-solana",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "rpc-websockets": "^7.10.0"
       },
       "devDependencies": {
         "nock": "^13.3.3"
@@ -9125,14 +9127,14 @@
     },
     "platforms/solana/protocols/cctp": {
       "name": "@wormhole-foundation/sdk-solana-cctp",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-solana": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -9140,14 +9142,14 @@
     },
     "platforms/solana/protocols/core": {
       "name": "@wormhole-foundation/sdk-solana-core",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-solana": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -9155,15 +9157,15 @@
     },
     "platforms/solana/protocols/tokenBridge": {
       "name": "@wormhole-foundation/sdk-solana-tokenbridge",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-solana-core": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-solana": "0.10.0",
+        "@wormhole-foundation/sdk-solana-core": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -9171,11 +9173,11 @@
     },
     "platforms/sui": {
       "name": "@wormhole-foundation/sdk-sui",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -9183,12 +9185,12 @@
     },
     "platforms/sui/protocols/core": {
       "name": "@wormhole-foundation/sdk-sui-core",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-sui": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-sui": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -9196,13 +9198,13 @@
     },
     "platforms/sui/protocols/tokenBridge": {
       "name": "@wormhole-foundation/sdk-sui-tokenbridge",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-sui": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-sui-core": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-sui": "0.10.0",
+        "@wormhole-foundation/sdk-sui-core": "0.10.0"
       },
       "engines": {
         "node": ">=16"
@@ -9210,34 +9212,34 @@
     },
     "sdk": {
       "name": "@wormhole-foundation/sdk",
-      "version": "0.7.3-beta.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-algorand-core": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-aptos": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-aptos-core": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-base": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm-cctp": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm-core": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm-portico": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-solana-cctp": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-solana-core": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-sui": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-sui-core": "0.7.3-beta.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "0.7.3-beta.0"
+        "@wormhole-foundation/sdk-algorand": "0.10.0",
+        "@wormhole-foundation/sdk-algorand-core": "0.10.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.10.0",
+        "@wormhole-foundation/sdk-aptos": "0.10.0",
+        "@wormhole-foundation/sdk-aptos-core": "0.10.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.10.0",
+        "@wormhole-foundation/sdk-base": "0.10.0",
+        "@wormhole-foundation/sdk-connect": "0.10.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.10.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.10.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.10.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.10.0",
+        "@wormhole-foundation/sdk-definitions": "0.10.0",
+        "@wormhole-foundation/sdk-evm": "0.10.0",
+        "@wormhole-foundation/sdk-evm-cctp": "0.10.0",
+        "@wormhole-foundation/sdk-evm-core": "0.10.0",
+        "@wormhole-foundation/sdk-evm-portico": "0.10.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.10.0",
+        "@wormhole-foundation/sdk-solana": "0.10.0",
+        "@wormhole-foundation/sdk-solana-cctp": "0.10.0",
+        "@wormhole-foundation/sdk-solana-core": "0.10.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "0.10.0",
+        "@wormhole-foundation/sdk-sui": "0.10.0",
+        "@wormhole-foundation/sdk-sui-core": "0.10.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "0.10.0"
       },
       "engines": {
         "node": ">=16"

--- a/platforms/solana/package.json
+++ b/platforms/solana/package.json
@@ -49,11 +49,12 @@
     "nock": "^13.3.3"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-connect": "0.10.0",
-    "@coral-xyz/borsh": "0.29.0",
     "@coral-xyz/anchor": "0.29.0",
+    "@coral-xyz/borsh": "0.29.0",
     "@solana/spl-token": "0.3.9",
-    "@solana/web3.js": "1.91.7"
+    "@solana/web3.js": "1.91.7",
+    "@wormhole-foundation/sdk-connect": "0.10.0",
+    "rpc-websockets": "^7.10.0"
   },
   "type": "module",
   "typesVersions": {


### PR DESCRIPTION
Fixes this issue: https://stackoverflow.com/questions/78566652/solana-web3-js-cannot-find-module-rpc-websockets-dist-lib-client