### PR TITLE
Add Snaxchain mainnet support

### DIFF
--- a/core/base/src/constants/contracts/core.ts
+++ b/core/base/src/constants/contracts/core.ts
@@ -38,7 +38,8 @@ export const coreBridgeContracts = [[
     ["Neutron",   "neutron16rerygcpahqcxx5t8vjla46ym8ccn7xz7rtc6ju5ujcd36cmc7zs9zrunh"],
     ["Blast",     "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"],
     ["Scroll",    "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"],
-    ["Mantle",    "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"]
+    ["Mantle",    "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"],
+    ["Snaxchain", "0xc1BA3CC4bFE724A08FbbFbF64F8db196738665f4"],
   ]], [
   "Testnet", [
     ["Solana",          "3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5"],

--- a/core/base/src/constants/contracts/relayer.ts
+++ b/core/base/src/constants/contracts/relayer.ts
@@ -20,6 +20,7 @@ export const relayerContracts = [[
     ["Scroll",    "0x27428DD2d3DD32A4D7f7C497eAaa23130d894911"],
     ["Mantle",    "0x27428DD2d3DD32A4D7f7C497eAaa23130d894911"],
     ["Xlayer",    "0x27428DD2d3DD32A4D7f7C497eAaa23130d894911"],
+    ["Snaxchain", "0x27428DD2d3DD32A4D7f7C497eAaa23130d894911"],
   ]], [
   "Testnet", [
     ["Ethereum",        "0x28D8F1Be96f97C1387e94A53e00eCcFb4E75175a"],

--- a/core/base/src/constants/contracts/tokenBridge.ts
+++ b/core/base/src/constants/contracts/tokenBridge.ts
@@ -35,6 +35,7 @@ export const tokenBridgeContracts = [[
     ["Blast",     "0x24850c6f61C438823F01B7A3BF2B89B72174Fa9d"],
     ["Scroll",    "0x24850c6f61C438823F01B7A3BF2B89B72174Fa9d"],
     ["Mantle",    "0x24850c6f61C438823F01B7A3BF2B89B72174Fa9d"],
+    ["Snaxchain", "0x8B94bfE456B48a6025b92E11Be393BAa86e68410"],
   ]], [
   "Testnet", [
     ["Solana",          "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe"],

--- a/core/base/src/constants/nativeChainIds.ts
+++ b/core/base/src/constants/nativeChainIds.ts
@@ -53,6 +53,7 @@ const chainNetworkNativeChainIdEntries = [
       ["Scroll",    534352n],
       ["Blast",     81457n],
       ["Linea",     59144n],
+      ["Snaxchain", 2192n],
     ],
   ],
   [
@@ -104,7 +105,7 @@ const chainNetworkNativeChainIdEntries = [
       ["Mantle",          5003n], // Sepolia testnet
       ["Scroll",          534351n],
       ["Berachain",       80084n], // Testnet v2
-      ["Snaxchain",       2192n],
+      ["Snaxchain",       13001n],
       ["Xlayer",          195n],
       ["Linea",           59141n], // Sepolia
     ],


### PR DESCRIPTION
This PR enables Snaxchain mainnet support. It also updates the testnet deployment since they changed the EVM chain ID for it.

The mainnet contracts are here:

- [Core bridge](https://explorer.snaxchain.io/address/0xc1BA3CC4bFE724A08FbbFbF64F8db196738665f4)
- [Token bridge](https://explorer.snaxchain.io/address/0x8B94bfE456B48a6025b92E11Be393BAa86e68410)
- [Automatic relayer](https://explorer.snaxchain.io/address/0x27428DD2d3DD32A4D7f7C497eAaa23130d894911)

The testnet contracts are here:

- [Core bridge](https://testnet-explorer.snaxchain.io/address/0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd)
- [Token bridge](https://testnet-explorer.snaxchain.io/address/0xa10f2eF61dE1f19f586ab8B6F2EbA89bACE63F7a)