### PR TITLE
add `QuoteUnavailable` type

### DIFF
--- a/connect/src/routes/types.ts
+++ b/connect/src/routes/types.ts
@@ -34,7 +34,7 @@ export type QuoteResult<
   OP,
   VP extends ValidatedTransferParams<OP> = ValidatedTransferParams<OP>,
   D = any,
-> = Quote<OP, VP, D> | QuoteError;
+> = Quote<OP, VP, D> | QuoteError | QuoteUnavailable;
 
 // Quote containing expected details of the transfer
 export type Quote<
@@ -83,4 +83,9 @@ export type Quote<
 export type QuoteError = {
   success: false;
   error: Error;
+};
+
+export type QuoteUnavailable = {
+  success: false;
+  unavailable: true;
 };


### PR DESCRIPTION
This type is meant to be used when we fail to fetch a quote, but don't want to expose that error to the user because there's no action they can take to resolve it.

For example, right now [the `MayanRoute` returns a generic error when it fails to fetch a quote](https://github.com/mayan-finance/wormhole-sdk-route/blob/main/src/index.ts#L236). A user who sees this error string in a UI has no resource. Instead, this route would return a `QuoteUnavailable` value to signal to a UI that just shouldn't show this route.

There used to be an `isAvailable` method, but that was problematic because it was separate from the `quote` method and so it required fetching a quote twice back-to-back; once to figure out availability and a second time just to get the quote details. This was wasteful. I recently removed that method, and now I guess I'm bringing the concept back but as part of the fetching-a-quote step.