### PR TITLE
`amount.display`: Don't add trailing zeros by default

### DIFF
--- a/core/base/src/utils/amount.ts
+++ b/core/base/src/utils/amount.ts
@@ -156,6 +156,7 @@ export function display(amount: Amount, precision?: number): string {
       if (partial[partial.length - 1] !== "0") break;
       partial = partial.substring(0, partial.length - 1);
     }
+    partial = partial.padEnd(precision, "0");
   } else {
     // If no specific precision is given, just trim trailing zeroes
     // and return all significant digits.

--- a/core/base/src/utils/amount.ts
+++ b/core/base/src/utils/amount.ts
@@ -156,7 +156,10 @@ export function display(amount: Amount, precision?: number): string {
       if (partial[partial.length - 1] !== "0") break;
       partial = partial.substring(0, partial.length - 1);
     }
-    partial = partial.padEnd(precision, "0");
+  } else {
+    // If no specific precision is given, just trim trailing zeroes
+    // and return all significant digits.
+    partial = partial.replace(/0+$/, '');
   }
 
   return partial.length > 0 ? `${whole}.${partial}` : whole;


### PR DESCRIPTION
Trivial change. If you don't specify `precision`, `amount.display` will now only return up to the final significant digit and no trailing zeroes :)