### PR TITLE
fix, cleanup, and tighten type programming utils

### DIFF
--- a/core/base/src/constants/guardians.ts
+++ b/core/base/src/constants/guardians.ts
@@ -1,5 +1,5 @@
 import type { MapLevels} from './../utils/index.js';
-import { constMap, column, cartesianRightRecursive } from './../utils/index.js';
+import { constMap, filterIndexes, zip, cartesianRightRecursive } from './../utils/index.js';
 import type { Network } from './networks.js';
 
 // prettier-ignore
@@ -30,8 +30,8 @@ const guardianKeyAndNameEntries = [[
   ]]
 ] as const satisfies MapLevels<[Network, string, string]>;
 
-export const guardianKeys = column(cartesianRightRecursive(guardianKeyAndNameEntries), 1);
-export const guardianNames = column(cartesianRightRecursive(guardianKeyAndNameEntries), 2);
+export const [guardianKeys, guardianNames] =
+  filterIndexes(zip(cartesianRightRecursive(guardianKeyAndNameEntries)), [1, 2]);
 
 export const guardianNameToKey = constMap(guardianKeyAndNameEntries, [[0, 2], 1]);
 export const guardianKeyToName = constMap(guardianKeyAndNameEntries, [1, [0, 2]]);

--- a/core/base/src/utils/array.ts
+++ b/core/base/src/utils/array.ts
@@ -108,6 +108,12 @@ type ExcludeIndexesImpl<T extends RoArray, C extends number> =
 export type ExcludeIndexes<T extends RoArray, C extends IndexEs> =
   ExcludeIndexesImpl<Entries<T>, C extends RoArray<number> ? C[number] : C>;
 
+export const excludeIndexes =
+  <const T extends RoArray, const C extends IndexEs>(arr: T, indexes: C) => {
+    const indexSet = new Set(Array.isArray(indexes) ? indexes : [indexes]);
+    return arr.filter((_,i) => !indexSet.has(i)) as ExcludeIndexes<T, C>;
+  };
+
 export type Cartesian<L, R> =
   L extends RoArray
   ? Flatten<[...{ [K in keyof L]: K extends `${number}` ? Cartesian<L[K], R> : never }]>

--- a/core/base/src/utils/array.ts
+++ b/core/base/src/utils/array.ts
@@ -64,7 +64,7 @@ type StripArray<T> = T extends RoArray<infer E> ? E : T;
 export type Flatten<A extends RoArray> =
   A extends RoTuple
   ? TupleFlatten<A>
-  : RoArray<StripArray<A[number]>>;
+  : StripArray<A[number]>[];
 
 export const flatten = <const A extends RoArray>(arr: A) =>
   arr.flat() as Flatten<A>;
@@ -110,7 +110,7 @@ export type TupleZip<T extends RoTuple2D> =
 export type Zip<A extends RoArray2D> =
   A extends RoTuple2D
   ? TupleZip<A>
-  : RoArray2D<Flatten<A>[number]>;
+  : Flatten<A>[number][][];
 
 export const zip = <const Args extends RoArray2D>(arr: Args) =>
   range(arr[0]!.length).map(col =>

--- a/core/base/src/utils/array.ts
+++ b/core/base/src/utils/array.ts
@@ -1,63 +1,94 @@
-import type { RoArray, RoArray2D, IsUnion } from './metaprogramming.js';
+import type { RoPair, RoTuple, RoArray, Extends, Xor, Not } from './metaprogramming.js';
 
-export const range = (length: number) => [...Array(length).keys()];
+export type RoTuple2D<T = unknown> = RoTuple<RoTuple<T>>;
+export type RoArray2D<T = unknown> = RoArray<RoArray<T>>;
 
-//TODO the intent here is that number represents a number literal, but strictly speaking
-//  the type allows for unions of number literals (and an array of such unions)
-//The reason for not just sticking to unions is that unions lose order information which is
-//  relevant in some cases (and iterating over them is a pain).
-export type IndexEs = number | RoArray<number>;
+export type TupleWithLength<T, L extends number, A extends T[] = []> =
+  A["length"] extends L ? A : TupleWithLength<T, L, [...A, T]>;
 
-export type ElementIndexPairs<T extends RoArray> =
-  [...{ [K in keyof T]: K extends `${infer N extends number}` ? [T[K], N] : never }];
+export type RoTupleWithLength<T, L extends number> = Readonly<TupleWithLength<T, L>>;
 
-export const elementIndexPairs = <const T extends RoArray>(arr: T) =>
-  range(arr.length).map(i => [arr[i], i]) as ElementIndexPairs<T>;
+export type TupleRange<L extends number, A extends number[] = []> =
+  A["length"] extends L
+  ? A
+  : TupleRange<L, [...A, A["length"]]>;
 
-export type Entries<T extends RoArray> =
+export type Range<L extends number> =
+  number extends L
+  ? number[]
+  : TupleRange<L>;
+
+export const range = <const L extends number>(length: L) =>
+  [...Array(length).keys()] as Range<L>;
+
+//capitalization to highlight that this is intended to be a literal or a union of literals
+export type IndexEs = number;
+
+//utility type to reduce boilerplate of iteration code by replacing:
+// `T extends readonly [infer Head extends T[number], ...infer Tail extends RoTuple<T[number]>]`
+//with just:
+// `T extends HeadTail<infer Head, infer Tail>`
+//this also avoids the somewhat common mistake of accidentally dropping the readonly modifier
+export type HeadTail<T extends RoTuple, Head extends T[number], Tail extends RoTuple<T[number]>> =
+  readonly [Head, ...Tail];
+
+export type TupleEntries<T extends RoTuple> =
   [...{ [K in keyof T]: K extends `${infer N extends number}` ? [N, T[K]] : never }];
 
-export const entries = <const T extends RoArray>(arr: T) =>
-  range(arr.length).map(i => [i, arr[i]]) as Entries<T>;
+//const aware version of Array.entries
+export type Entries<T extends RoArray> =
+  T extends RoTuple
+  ? TupleEntries<T>
+  : T extends RoArray<infer U>
+  ? [number, U][]
+  : never;
 
-export type Flatten<T extends RoArray> =
-  T extends readonly [infer Head, ...infer Tail extends RoArray]
-  ? Head extends RoArray
-    ? [...Head, ...Flatten<Tail>]
-    : [Head, ...Flatten<Tail>]
+export function entries<const T extends RoTuple>(arr: T): TupleEntries<T>;
+export function entries<const T extends RoArray>(arr: T): Entries<T>;
+export function entries(arr: readonly any[]): [number, any][] {
+  return [...arr.entries()];
+}
+
+export type IsArray<T> = T extends RoArray<any> ? true : false;
+export type IsFlat<A extends RoArray> = true extends IsArray<A[number]> ? false : true;
+
+export type TupleFlatten<T extends RoTuple> =
+  T extends HeadTail<T, infer Head, infer Tail>
+  ? Head extends RoTuple
+    ? [...Head, ...TupleFlatten<Tail>]
+    : [Head, ...TupleFlatten<Tail>]
   : [];
 
-export type InnerFlatten<T extends RoArray> =
-  [...{ [K in keyof T]:
+type StripArray<T> = T extends RoArray<infer E> ? E : T;
+
+export type Flatten<A extends RoArray> =
+  A extends RoTuple
+  ? TupleFlatten<A>
+  : RoArray<StripArray<A[number]>>;
+
+export const flatten = <const A extends RoArray>(arr: A) =>
+  arr.flat() as Flatten<A>;
+
+export type InnerFlatten<A extends RoArray> =
+  [...{ [K in keyof A]:
     K extends `${number}`
-    ? T[K] extends RoArray
-      ? Flatten<T[K]>
-      : T[K]
+    ? A[K] extends RoArray
+      ? Flatten<A[K]>
+      : A[K]
     : never
   }];
 
-export type IsFlat<T extends RoArray> =
-  T extends readonly [infer Head, ...infer Tail extends RoArray]
-  ? Head extends RoArray
-    ? false
-    : IsFlat<Tail>
-  : true;
+export type Unflatten<A extends RoArray> =
+  [...{ [K in keyof A]: K extends `${number}` ? [A[K]] : never }];
 
-export type Unflatten<T extends RoArray> =
-  [...{ [K in keyof T]: K extends `${number}` ? [T[K]] : never }];
-
-export type AllSameLength<T extends RoArray2D, L extends number | void = void> =
-  T extends readonly [infer Head extends RoArray, ...infer Tail extends RoArray2D]
-  ? L extends void
-    ? AllSameLength<Tail, Head["length"]>
-    : Head["length"] extends L
-    ? AllSameLength<Tail, L>
-    : false
-  : true;
-
-export type IsRectangular<T extends RoArray> =
-  //1d array is rectangular
-  T extends RoArray2D ? AllSameLength<T> : IsFlat<T>;
+export type IsRectangular<T extends RoTuple> =
+  T extends RoTuple2D
+  ? T extends HeadTail<T, infer Head extends RoTuple, infer Tail extends RoTuple2D>
+    ? Tail extends readonly []
+      ? true //a column is rectangular
+      : Tail[number]["length"] extends Head["length"] ? true : false
+    : true //empty is rectangular
+  : true; //a row is rectangular
 
 export type Column<A extends RoArray2D, I extends number> =
   [...{ [K in keyof A]: K extends `${number}` ? A[K][I] : never }];
@@ -65,54 +96,66 @@ export type Column<A extends RoArray2D, I extends number> =
 export const column = <const A extends RoArray2D, const I extends number>(tupArr: A, index: I) =>
   tupArr.map((tuple) => tuple[index]) as Column<A, I>;
 
-export type Zip<A extends RoArray2D> =
-  //TODO remove, find max length, and return undefined for elements in shorter arrays
-  A["length"] extends 0
-  ? []
-  : IsRectangular<A> extends true
-  ? A[0] extends infer Head extends RoArray
+export type TupleZip<T extends RoTuple2D> =
+  IsRectangular<T> extends true
+  ? T[0] extends infer Head extends RoTuple
     ? [...{ [K in keyof Head]:
         K extends `${number}`
-        ? [...{ [K2 in keyof A]: K extends keyof A[K2] ? A[K2][K] : never }]
+        ? [...{ [K2 in keyof T]: K extends keyof T[K2] ? T[K2][K] : never }]
         : never
       }]
     : []
-  : never
+  : never;
+
+export type Zip<A extends RoArray2D> =
+  A extends RoTuple2D
+  ? TupleZip<A>
+  : RoArray2D<Flatten<A>[number]>;
 
 export const zip = <const Args extends RoArray2D>(arr: Args) =>
   range(arr[0]!.length).map(col =>
     range(arr.length).map(row => arr[row]![col])
-  ) as unknown as ([Zip<Args>] extends [never] ? RoArray2D : Zip<Args>);
+  ) as Zip<Args>;
 
 //extracts elements with the given indexes in the specified order, explicitly forbid unions
-export type OnlyIndexes<E extends RoArray, I extends IndexEs> =
-  IsUnion<I> extends false
-    ? I extends number
-    ? OnlyIndexes<E, [I]>
-    : I extends readonly [infer Head extends number, ...infer Tail extends RoArray<number>]
-    ? E[Head] extends undefined
-      ? OnlyIndexes<E, Tail>
-      : [E[Head], ...OnlyIndexes<E, Tail>]
-    : []
-  : never;
+export type TuplePickWithOrder<A extends RoArray, I extends RoTuple<number>> =
+  I extends HeadTail<I, infer Head, infer Tail>
+  ? A[Head] extends undefined
+    ? TuplePickWithOrder<A, Tail>
+    : [A[Head], ...TuplePickWithOrder<A, Tail>]
+  : [];
 
-type ExcludeIndexesImpl<T extends RoArray, C extends number> =
-  T extends readonly [infer Head, ...infer Tail]
-  ? Head extends readonly [infer I extends number, infer V]
-    ? I extends C
-      ? ExcludeIndexesImpl<Tail, C>
-      : [V, ...ExcludeIndexesImpl<Tail, C>]
+export type PickWithOrder<A extends RoArray, I extends RoArray<number>> =
+  [A, I] extends [infer T extends RoTuple, infer TI extends RoTuple<number>]
+  ? TuplePickWithOrder<T, TI>
+  : A;
+
+export const pickWithOrder =
+  <const A extends RoArray, const I extends RoArray<number>>(arr: A, indexes: I) =>
+    indexes.map((i) => arr[i]) as PickWithOrder<A, I>;
+
+type FilterIndexesImpl<T extends RoTuple, I extends IndexEs, E extends boolean> =
+  T extends HeadTail<T, infer Head, infer Tail>
+  ? Head extends RoPair<infer J extends number, infer V>
+    ? Not<Xor<Not<E>, Extends<J, I>>> extends true
+      ? [V, ...FilterIndexesImpl<Tail, I, E>]
+      : FilterIndexesImpl<Tail, I, E>
     : never
   : [];
 
-export type ExcludeIndexes<T extends RoArray, C extends IndexEs> =
-  ExcludeIndexesImpl<Entries<T>, C extends RoArray<number> ? C[number] : C>;
+export type FilterIndexes<A extends RoArray, I extends IndexEs, E extends boolean = false> =
+  A extends infer T extends RoTuple
+  ? FilterIndexesImpl<Entries<T>, I, E>
+  : A;
 
-export const excludeIndexes =
-  <const T extends RoArray, const C extends IndexEs>(arr: T, indexes: C) => {
-    const indexSet = new Set(Array.isArray(indexes) ? indexes : [indexes]);
-    return arr.filter((_,i) => !indexSet.has(i)) as ExcludeIndexes<T, C>;
-  };
+export const filterIndexes = <
+  const T extends RoArray,
+  const I extends RoArray<number>,
+  const E extends boolean = false
+>(arr: T, indexes: I, exclude?: E) => {
+  const indexSet = new Set(Array.isArray(indexes) ? indexes : [indexes]);
+  return arr.filter((_,i) => indexSet.has(i) !== exclude) as FilterIndexes<T, I[number], E>;
+};
 
 export type Cartesian<L, R> =
   L extends RoArray

--- a/core/base/src/utils/mapping.ts
+++ b/core/base/src/utils/mapping.ts
@@ -63,22 +63,22 @@
 //VR = value rows
 
 import type {
-  IndexEs,
+  RoTuple2D,
+  RoArray2D,
+  HeadTail,
+  Entries,
   Flatten,
   InnerFlatten,
   IsRectangular,
-  Zip,
+  TupleZip,
   Cartesian,
-  OnlyIndexes,
-  ExcludeIndexes,
-  ElementIndexPairs,
+  TuplePickWithOrder,
 } from './array.js';
 import { range, zip } from './array.js';
-import type { Widen, RoArray, RoArray2D, RoPair } from './metaprogramming.js';
+import type { Widen, RoTuple, RoNeTuple, RoArray, RoPair } from './metaprogramming.js';
 
-
-export type ShallowMapping<M extends RoArray<readonly [PropertyKey, unknown]>> =
-  { readonly [E in M[number]as E[0]]: E[1] };
+export type ShallowMapping<M extends RoTuple<readonly [PropertyKey, unknown]>> =
+  { readonly [E in M[number] as E[0]]: E[1] };
 
 //symbol probably shouldn't be part of the union (but then our type isn't a superset of PropertyKey
 //  anymore which comes with its own set of headaches)
@@ -87,11 +87,11 @@ function isMappableKey(key: unknown): key is MappableKey {
   return ["string", "number", "symbol", "bigint", "boolean"].includes(typeof key);
 }
 
-export type MapLevel<K extends MappableKey, V> = RoArray<RoPair<K, V>>;
+export type MapLevel<K extends MappableKey, V> = RoTuple<RoPair<K, V>>;
 
-type MapLevelsTuple = readonly [MappableKey, ...RoArray<MappableKey>, unknown];
+type MapLevelsTuple = readonly [MappableKey, ...RoTuple<MappableKey>, unknown];
 export type MapLevels<T extends MapLevelsTuple> =
-  T extends readonly [infer Head extends MappableKey, ...infer Tail extends RoArray<unknown>]
+  T extends HeadTail<T,infer Head extends MappableKey, infer Tail>
   ? Tail extends MapLevelsTuple
     ? MapLevel<Head, MapLevels<Tail>>
     : MapLevel<Head, Tail[0]>
@@ -114,7 +114,7 @@ type FromExtPropKey<T extends PropertyKey> =
   : T;
 
 type MappingEntry<V = unknown> = RoPair<MappableKey, V>;
-type MappingEntries<V = unknown> = RoArray<MappingEntry<V>>;
+type MappingEntries<V = unknown> = RoTuple<MappingEntry<V>>;
 
 //Recursively sifts through T combining all row indexes that have key K.
 //Matching rows (i.e. those with key K) have their indexes placed in IA, non-matching (unfiltered)
@@ -122,13 +122,10 @@ type MappingEntries<V = unknown> = RoArray<MappingEntry<V>>;
 type CombineKeyRowIndexes<
   K extends MappableKey,
   T extends MappingEntries<number>,
-  IA extends RoArray<number>, //all values associated with K
+  IA extends RoTuple<number>, //all values associated with K
   U extends MappingEntries<number> = [], //rows that have been scanned and are not associated with K
 > =
-  T extends readonly [
-    infer Head extends MappingEntry<number>,
-    ...infer Tail extends MappingEntries<number>
-  ]
+  T extends HeadTail<T, infer Head, infer Tail>
   ? Head[0] extends K
     ? CombineKeyRowIndexes<K, Tail, [...IA, Head[1]], U>
     : CombineKeyRowIndexes<K, Tail, IA, [...U, Head]>
@@ -140,10 +137,10 @@ type CombineKeyRowIndexes<
 //  [["Mainnet", 0], ["Mainnet", 1], ["Mainnet", 2], ["Testnet", 3], ["Testnet", 4]]
 //into [["Mainnet", [0,1,2]], ["Testnet", [3,4]]].
 type ToMapEntries<KCI extends MappingEntries<number>, M extends MappingEntries = []> =
-  KCI extends readonly [infer Head, ...infer Tail extends MappingEntries<number>]
+  KCI extends HeadTail<KCI, infer Head, infer Tail>
   ? Head extends RoPair<infer K extends MappableKey, infer V extends number>
     ? CombineKeyRowIndexes<K, Tail, [V]> extends RoPair<
-        infer IA extends RoArray,
+        infer IA extends RoTuple,
         infer KCIU extends MappingEntries<number>
       >
       ? ToMapEntries<KCIU, [...M, [K, IA]]>
@@ -151,20 +148,39 @@ type ToMapEntries<KCI extends MappingEntries<number>, M extends MappingEntries =
     : never
   : M;
 
-type CartesianRightRecursive<M extends RoArray> =
-  M extends MappingEntries<RoArray>
-  ? Flatten<[...{ [K in keyof M]:
+type CartesianRightRecursive<M extends RoTuple> =
+  M extends infer IM extends MappingEntries<RoTuple>
+  ? Flatten<[...{ [K in keyof IM]:
     K extends `${number}`
-    ? InnerFlatten<Cartesian<M[K][0], CartesianRightRecursive<M[K][1]>>>
+    ? InnerFlatten<Cartesian<IM[K][0], CartesianRightRecursive<IM[K][1]>>>
     : never
   }]>
-  : M extends MappingEntry<RoArray>
-  ? Cartesian<M[0], M[1]>
+  : M extends infer IM extends MappingEntry<RoTuple>
+  ? Cartesian<IM[0], IM[1]>
   : M;
 
-type Shape = RoPair<IndexEs, IndexEs>; //key columns, value columns
-type CartesianSet<T = unknown> = RoArray2D<T>; //CartesianSet is always rectangular
-type Transpose<T extends RoArray2D> = Zip<T>;
+type Shape = RoPair<RoTuple<number>, RoTuple<number>>; //key columns, value columns
+type IndexLike = number | RoNeTuple<number>;
+type ShapeLike = RoPair<IndexLike, IndexLike>;
+type ShapeLikeToShape<S extends ShapeLike> =
+  S extends RoPair<infer KC extends IndexLike, infer VC extends IndexLike>
+  ? [KC extends number ? [KC] : KC, VC extends number ? [VC] : VC]
+  : never;
+
+type CartesianSet<T = unknown> = RoTuple2D<T>; //CartesianSet is always rectangular
+type Transpose<T extends RoTuple2D, E = unknown> =
+  TupleZip<T> extends infer R extends RoTuple2D<E>
+  ? R
+  : never;
+
+type FlipInnerPair<T extends RoTuple<RoPair>> =
+  [...{ [K in keyof T]: K extends `${number}` ? [T[K][1], T[K][0]] : never }];
+
+type KeyRowIndexes = MappingEntries<RoTuple<number>>;
+type KeyColumnToKeyRowIndexes<KC extends RoTuple<MappableKey>> =
+  FlipInnerPair<Entries<KC>> extends infer FIP extends MappingEntries<number>
+  ? ToMapEntries<FIP>
+  : never;
 
 //Takes the first of the reamining key columns and splits it into chunks that share the same key
 //  value. Then invokes itself for each sub-chunk passing along only those value rows that belong
@@ -172,23 +188,18 @@ type Transpose<T extends RoArray2D> = Zip<T>;
 //In our example for the default shape, it starts with the network column and splits it into
 //  the "Mainnet" and "Testnet" chunk. The first chunk gets the first 3 rows, the second chunk
 //  gets the last 2. Then the "Mainnet" chunk is recursively split into 3 chunks again, ...
-type ProcessNextKeyColmn<KC extends CartesianSet<MappableKey>, VR extends RoArray> =
-  KC["length"] extends 0
-  ? VR
-  : ExcludeIndexes<KC, 0> extends infer KCR extends CartesianSet<MappableKey>
-  //KRIA = key row indexes array
-  ? ToMapEntries<ElementIndexPairs<KC[0]>> extends infer KRIA extends MappingEntries<RoArray<number>>
-    ? [...{
-      [K in keyof KRIA]: [
-        KRIA[K][0],
+type ProcessNextKeyColmn<KC extends CartesianSet<MappableKey>, VR extends RoTuple> =
+  KC extends HeadTail<KC, infer Head, infer Tail>
+  ? KeyColumnToKeyRowIndexes<Exclude<Head, undefined>> extends infer KRI extends KeyRowIndexes
+    ? [...{ [K in keyof KRI]: [
+        KRI[K][0],
         ProcessNextKeyColmn<
-          Transpose<OnlyIndexes<Transpose<KCR>, KRIA[K][1]>>,
-          OnlyIndexes<VR, KRIA[K][1]>
+          Transpose<TuplePickWithOrder<Transpose<Tail>, KRI[K][1]>, MappableKey>,
+          TuplePickWithOrder<VR, KRI[K][1]>
         >
-      ]
-    }]
+      ]}]
     : never
-  : never;
+  : VR;
 
 //We encode leaf values as tuples of void (which does not constitute a value type and hence can't
 //  come from the user) and the actual value. This allows us to later distinguish whether a value
@@ -199,7 +210,7 @@ type LeafValue<T = unknown> = RoPair<void, T>;
 //Takes the value columns and combines them into leaf value rows.
 type CombineValueColumnsToLeafValues<VC extends CartesianSet> =
   //if we only have a single value column, we don't have to use tuples for values
-  (VC["length"] extends 1 ? VC[0] : Transpose<VC>) extends infer VCT extends RoArray
+  (VC["length"] extends 1 ? VC[0] : Transpose<VC>) extends infer VCT extends RoTuple
   ? [...{ [K in keyof VCT]: K extends `${number}` ? LeafValue<VCT[K]> : never }]
   : never;
 
@@ -207,19 +218,19 @@ type CombineValueColumnsToLeafValues<VC extends CartesianSet> =
 //  the specified shape.
 type SplitAndReorderKeyValueColumns<R extends CartesianSet, S extends Shape> =
   Transpose<R> extends infer C extends CartesianSet
-  ? [OnlyIndexes<C, S[0]>, OnlyIndexes<C, S[1]>]
+  ? [TuplePickWithOrder<C, S[0]>, TuplePickWithOrder<C, S[1]>]
   : never;
 
 //returns the mapping with "unwrapped" values (i.e. turns the singleton arrays back into their one
 //  constituent element) if all leaves are indeed singletons, otherwise returns void
 type UnwrapValuesIfAllAreSingletons<M extends MappingEntries, D extends Depth[number]> =
   D extends 1
-  ? M extends MappingEntries<readonly [LeafValue]>
-    ? [...{ [K in keyof M]: K extends `${number}` ? [M[K][0], M[K][1][0][1]] : never }]
+  ? M extends infer IM extends MappingEntries<readonly [LeafValue]>
+    ? [...{ [K in keyof IM]: K extends `${number}` ? [M[K][0], M[K][1][0][1]] : never }]
     : void
-  : M extends MappingEntries<MappingEntries>
-    ? [...{ [K in keyof M]: K extends `${number}`
-        ? [M[K][0], UnwrapValuesIfAllAreSingletons<M[K][1], Depth[D]>]
+  : M extends infer IM extends MappingEntries<MappingEntries>
+    ? [...{ [K in keyof IM]: K extends `${number}`
+        ? [IM[K][0], UnwrapValuesIfAllAreSingletons<IM[K][1], Depth[D]>]
         : never
       }] extends infer U extends MappingEntries
       ? U
@@ -232,28 +243,28 @@ type MaybeUnwrapValuesIfAllAreSingletons<M extends MappingEntries, D extends Dep
 //creates the transformed mapping and its key column count
 type TransformMapping<M extends MappingEntries, S extends Shape | void = void> =
   //check that M has a valid structure for mapping entries
-  CartesianRightRecursive<M> extends infer CRR extends RoArray2D
+  CartesianRightRecursive<M> extends infer CRR extends RoTuple2D
   ? IsRectangular<CRR> extends true
     //ensure CRR is not empty
-    ? CRR extends readonly [RoArray, ...RoArray2D]
+    ? CRR extends RoNeTuple<RoTuple>
       ? S extends Shape
         ? SplitAndReorderKeyValueColumns<CRR, S> extends [
           infer KC extends CartesianSet<MappableKey>,
           infer VC extends CartesianSet
         ]
-        ? KC["length"] extends Depth[number]
-          ? CombineValueColumnsToLeafValues<VC> extends infer VR extends RoArray<LeafValue>
+        ? KC["length"] extends infer D extends Depth[number]
+          ? CombineValueColumnsToLeafValues<VC> extends infer VR extends RoTuple<LeafValue>
             ? ProcessNextKeyColmn<KC, VR> extends infer TM extends MappingEntries
-              ? [MaybeUnwrapValuesIfAllAreSingletons<TM, KC["length"]>, KC["length"]]
+              ? [MaybeUnwrapValuesIfAllAreSingletons<TM, D>, D]
               : never
             : never
           : never
         : never
       //if we don't have an explicit shape, take the first row and subtract 1 (for the value
       //  column) to determine the count of key columns
-      : CRR[0] extends readonly [...infer KC extends RoArray, unknown]
-        ? KC["length"] extends Depth[number]
-          ? [M, KC["length"]]
+      : CRR[0] extends readonly [...infer KC extends RoTuple, unknown]
+        ? KC["length"] extends infer D extends Depth[number]
+          ? [M, D]
           : never
         : never
       : never
@@ -267,7 +278,7 @@ type ObjectFromMappingEntries<M extends MappingEntries, D extends Depth[number]>
     ? D extends 1
       ? V extends LeafValue<infer T>
         ? T
-        : V extends RoArray<LeafValue>
+        : V extends RoTuple<LeafValue>
         ? [...{ [K2 in keyof V]: K2 extends `${number}` ? V[K2][1] : never }]
         : V
       : V extends MappingEntries
@@ -279,9 +290,9 @@ type ObjectFromMappingEntries<M extends MappingEntries, D extends Depth[number]>
 
 export type ToMappingAndDepth<
   M extends MappingEntries,
-  S extends Shape | void | undefined
+  S extends ShapeLike | undefined
 > =
-  TransformMapping<M, S extends undefined ? void : S> extends [
+  TransformMapping<M, S extends ShapeLike ? ShapeLikeToShape<S> : void> extends [
     infer TM extends MappingEntries,
     infer D extends Depth[number],
   ]
@@ -290,13 +301,13 @@ export type ToMappingAndDepth<
 
 export type ToMapping<
   M extends MappingEntries,
-  S extends Shape | void | undefined = undefined
+  S extends ShapeLike | undefined = undefined
 > = ToMappingAndDepth<M, S>[0];
 
 type Mapped = { [key: PropertyKey]: unknown | Mapped };
 
-type RecursiveAccess<M, KA extends RoArray<MappableKey>> =
-  KA extends readonly [infer Head extends MappableKey, ...infer Tail extends RoArray<MappableKey>]
+type RecursiveAccess<M, KA extends RoTuple<MappableKey>> =
+  KA extends HeadTail<KA, infer Head, infer Tail>
   ? M extends Mapped
     ? RecursiveAccess<M[ToExtPropKey<Head>], Tail>
     : never
@@ -306,22 +317,22 @@ type RecursiveAccess<M, KA extends RoArray<MappableKey>> =
 //  as to avoid having to hardcode arity...)
 type GenericMappingFunc<M extends Mapped, D extends number> =
   D extends 1
-  ? <const K1 extends FromExtPropKey<keyof M>>(...args: [K1]) => RecursiveAccess<M, [K1]>
+  ? <const K1 extends FromExtPropKey<keyof M>>(...args: readonly [K1]) => RecursiveAccess<M, [K1]>
   : D extends 2
   ? <const K1 extends FromExtPropKey<keyof M>,
      const K2 extends FromExtPropKey<keyof RecursiveAccess<M, [K1]>>,
-    >(...args: [K1, K2]) => RecursiveAccess<M, [K1, K2]>
+    >(...args: readonly [K1, K2]) => RecursiveAccess<M, [K1, K2]>
   : D extends 3
   ? <const K1 extends FromExtPropKey<keyof M>,
      const K2 extends FromExtPropKey<keyof RecursiveAccess<M, [K1]>>,
      const K3 extends FromExtPropKey<keyof RecursiveAccess<M, [K1, K2]>>,
-    >(...args: [K1, K2, K3]) => RecursiveAccess<M, [K1, K2, K3]>
+    >(...args: readonly [K1, K2, K3]) => RecursiveAccess<M, [K1, K2, K3]>
   : D extends 4
   ? <const K1 extends FromExtPropKey<keyof M>,
      const K2 extends FromExtPropKey<keyof RecursiveAccess<M, [K1]>>,
      const K3 extends FromExtPropKey<keyof RecursiveAccess<M, [K1, K2]>>,
      const K4 extends FromExtPropKey<keyof RecursiveAccess<M, [K1, K2, K3]>>,
-    >(...args: [K1, K2, K3, K4]) => RecursiveAccess<M, [K1, K2, K3, K4]>
+    >(...args: readonly [K1, K2, K3, K4]) => RecursiveAccess<M, [K1, K2, K3, K4]>
   : never;
 
 type SubMap<M extends Mapped, D extends number, K extends PropertyKey> =
@@ -350,7 +361,7 @@ type WidenedParamsAndRet<M extends Mapped, D extends number> =
   [Widen<FromExtPropKey<KeysOfObjectUnion<M>>>, ...WidenedParamsAndRetRec<M, D>];
 
 type HasGetFuncs<M extends Mapped, D extends number> = 
-  WidenedParamsAndRet<M, D> extends [...infer P extends RoArray<unknown>, infer R]
+  WidenedParamsAndRet<M, D> extends [...infer P extends RoTuple<unknown>, infer R]
   ? { readonly has: (...args: P) => boolean, readonly get: (...args: P) => R | undefined }
   : never;
 
@@ -359,7 +370,7 @@ type ConstMap<M extends Mapped, D extends number> =
   ? GenericMappingFunc<M, D> & HasGetFuncs<M, D>
   : GenericMappingFunc<M, D> & HasGetFuncs<M, D> & SubMapFunc<M, D>;
 
-type ToConstMap<M extends MappingEntries, S extends Shape | undefined = undefined> =
+type ToConstMap<M extends MappingEntries, S extends ShapeLike | undefined = undefined> =
   ToMappingAndDepth<M, S> extends [infer TM extends Mapped, infer D extends Depth[number]]
   ? ConstMap<TM, D>
   : never;
@@ -368,24 +379,24 @@ const isRecursiveTuple = (arr: RoArray) =>
   arr.length === 2 && !Array.isArray(arr[0]) && Array.isArray(arr[1]);
 
 export const cartesianRightRecursive =
-  <const T extends RoArray>(arr: T): CartesianRightRecursive<T> => (
+  <const T extends RoTuple>(arr: T): CartesianRightRecursive<T> => (
     arr.length === 0
       ? []
       : Array.isArray(arr[0])
         ? (arr as MappingEntries).map(([key, val]) =>
           Array.isArray(val)
-            ? (isRecursiveTuple(val) ? cartesianRightRecursive(val) : val)
+            ? (isRecursiveTuple(val) ? cartesianRightRecursive(val as unknown as RoTuple) : val)
               .map(ele => [key, ele].flat())
             : [[key, val]]
         ).flat()
         : isRecursiveTuple(arr)
-          ? cartesianRightRecursive(arr[1] as RoArray).map((ele: any) => [arr[0], ele])
+          ? cartesianRightRecursive(arr[1] as RoTuple).map((ele: any) => [arr[0], ele])
           : arr
   ) as CartesianRightRecursive<T>;
 
 const toMapping = <
   const M extends MappingEntries,
-  const S extends Shape | undefined = undefined
+  const S extends ShapeLike | undefined = undefined
 >(mapping: M, shape?: S): ToMapping<M, S> => {
   const crr = cartesianRightRecursive(mapping);
   if (crr.length === 0)
@@ -400,7 +411,7 @@ const toMapping = <
   let allSingletons = true;
   const buildMappingRecursively = (
     keyCartesianSet: CartesianSet<MappableKey>,
-    values: RoArray<RoArray>
+    values: RoArray2D
   ): any => {
     const distinctKeys = Array.from(new Set<MappableKey>(keyCartesianSet[0]).values());
     const keyRows = new Map<MappableKey, number[]>(distinctKeys.map(key => [key, []]));
@@ -460,10 +471,7 @@ const toMapping = <
       if (!isMappableKey(key))
         throw new Error(`Invalid key: ${key} in ${keyCol}`);
 
-  const ret = buildMappingRecursively(
-    keyCartesianSet as CartesianSet<MappableKey>,
-    zip(leafValues!)
-  );
+  const ret = buildMappingRecursively(keyCartesianSet! as any, zip(leafValues!));
 
   if (allSingletons)
     for (const leafObj of leafObjects)
@@ -475,7 +483,7 @@ const toMapping = <
 
 export function constMap<
   const M extends MappingEntries,
-  const S extends Shape | undefined = undefined,
+  const S extends ShapeLike | undefined = undefined,
 >(mappingEntries: M, shape?: S): ToConstMap<M, S> {
   const mapping = toMapping(mappingEntries, shape);
   const genericMappingFunc = ((...args: MappableKey[]) =>
@@ -484,10 +492,10 @@ export function constMap<
       mapping
     ));
   return Object.assign(genericMappingFunc, {
-    has: (...args: readonly MappableKey[]) => genericMappingFunc(...args) !== undefined,
-    get: (...args: readonly MappableKey[]) => genericMappingFunc(...args),
+    has: (...args: RoArray<MappableKey>) => genericMappingFunc(...args) !== undefined,
+    get: (...args: RoArray<MappableKey>) => genericMappingFunc(...args),
     subMap: (key: MappableKey) => (mapping as any)[key.toString()],
-  }) as ToConstMap<M, S>;
+  }) as unknown as ToConstMap<M, S>;
 }
 
 //--- find a bunch of "tests" below

--- a/core/base/src/utils/mapping.ts
+++ b/core/base/src/utils/mapping.ts
@@ -410,7 +410,7 @@ const toMapping = <
   let leafObjects = [] as any[];
   let allSingletons = true;
   const buildMappingRecursively = (
-    keyCartesianSet: CartesianSet<MappableKey>,
+    keyCartesianSet: MappableKey[][],
     values: RoArray2D
   ): any => {
     const distinctKeys = Array.from(new Set<MappableKey>(keyCartesianSet[0]).values());
@@ -443,7 +443,7 @@ const toMapping = <
       const valuesSubset = rows.map(i => values[i]!);
       return [
         key,
-        buildMappingRecursively(keyCartesianSubset as CartesianSet<MappableKey>, valuesSubset)
+        buildMappingRecursively(keyCartesianSubset, valuesSubset)
       ];
     }));
   };

--- a/core/base/src/utils/metaprogramming.ts
+++ b/core/base/src/utils/metaprogramming.ts
@@ -1,11 +1,19 @@
 export type Extends<T, U> = [T] extends [U] ? true : false;
 
-//this is a generic overload of the built-in `Function` type, it should work as a more
-//  powerful drop-in replacement
-export type Function<P extends any[] = any[], R = any> = (...args: P) => R;
+export type NeTuple<T = unknown> = [T, ...T[]];
+export type Tuple<T = unknown> = NeTuple<T> | [];
+export type RoTuple<T = unknown> = Readonly<Tuple<T>>;
+export type RoNeTuple<T = unknown> = Readonly<NeTuple<T>>;
 export type RoArray<T = unknown> = readonly T[];
-export type RoArray2D<T = unknown> = RoArray<RoArray<T>>;
 export type RoPair<T = unknown, U = unknown> = readonly [T, U];
+//Function is is a generic overload of the built-in type
+//  It should work as a more powerful drop-in replacement.
+//  Since the built-in type is not generic and permissive, we have to use RoArray<any> as the
+//    default type of the parameters, otherwise `Test` would become false after our overload:
+// type TestFunc = (...args: [string, number]) => boolean;
+// type Test = TestFunc extends Function ? true : false; //true for built-in
+export type Function<P extends RoArray<unknown> = RoArray<any>, R = unknown> =
+  (...args: P) => R;
 
 export type Widen<T> =
   T extends string ? string :
@@ -22,15 +30,42 @@ export type IsAny<T> = Extends<0, 1 & T>;
 
 export type IsNever<T> = Extends<T, never>;
 
-//allow both And<reaonly boolean[]> and And<boolean, boolean>
-export type And<T extends RoArray<boolean> | boolean, R extends boolean = true> =
+export type Not<B extends boolean> = B extends true ? false : true;
+
+//empty And is true (neutral element)
+export type And<T extends RoTuple<boolean> | boolean, R extends boolean = true> =
   R extends true
-  ? T extends RoArray<boolean>
-    ? Extends<T[number], true>
-    : Extends<T, true>
+  ? T extends RoTuple<boolean>
+    ? false extends T[number]
+      ? false
+      : true
+    : T
   : false;
 
-export type Not<B extends boolean> = B extends true ? false : true;
+//empty And is false (neutral element)
+export type Or<T extends RoTuple<boolean> | boolean, R extends boolean = false> =
+  R extends false
+  ? T extends RoTuple<boolean>
+    ? true extends T[number]
+      ? true
+      : false
+    : T
+  : true;
+
+type XorImpl<T extends RoTuple<boolean>> =
+  T extends readonly [infer First, infer Second, ...infer Tail extends RoArray<boolean>]
+  ? XorImpl<[boolean extends First | Second ? true : false, ...Tail]> 
+  : T extends readonly [infer Final]
+  ? Final
+  : never; //Xor has no neutral element that we can return for the empty case
+
+//empty Xor is not supported (xor has no neutral element)
+export type Xor<T extends RoTuple<boolean> | boolean, R extends boolean | undefined = undefined> =
+  T extends RoTuple<boolean>
+  ? [...T, ...(undefined extends R ? [] : [Exclude<R, undefined>])] extends infer V extends RoTuple<boolean>
+    ? XorImpl<V>
+    : never
+  : boolean extends Exclude<R, undefined> | T ? true : false;
 
 export type ParseNumber<T> = T extends `${infer N extends number}` ? N : never;
 


### PR DESCRIPTION
The branch name is outdated. Initially intended to only add the one function that I needed, but then realized various issues in the code (primarily the usage of RoArray, when Tuple types were expected and "generic" RoArray that were not tuples under the hood actually produced incorrect results).

Types are now handled more appropriately and robustly.
e.g.
```
const arr = [[1,2], [3,4]];
const zipped = zip(arr); //previously had type never[], now has type RoArray2D<number>
```

The main downside is that compile time has gone up significantly (by 15 seconds, from 55s to 70s on my machine).