### PR TITLE
portico: fetch swap event

### DIFF
--- a/connect/src/types.ts
+++ b/connect/src/types.ts
@@ -6,7 +6,7 @@ import type {
   TokenId,
   TransactionId,
 } from "@wormhole-foundation/sdk-definitions";
-import type { QuoteWarning } from "./warnings.js";
+import type { TransferWarning, QuoteWarning } from "./warnings.js";
 
 // Transfer state machine states
 export enum TransferState {
@@ -105,6 +105,7 @@ export interface CompletedTransferReceipt<AT, SC extends Chain = Chain, DC exten
   originTxs: TransactionId<SC>[];
   attestation: AT;
   destinationTxs?: TransactionId<DC>[];
+  transferResult?: TransferResult;
 }
 
 export interface FailedTransferReceipt<AT, SC extends Chain = Chain, DC extends Chain = Chain>
@@ -202,7 +203,7 @@ export interface TransferQuote {
     token: TokenId;
     amount: bigint;
   };
-  // If the transfer being quoted asked for native gas dropoff
+  // If the transfer being quoted asked for native gas drop-off
   // this will contain the amount of native gas that is to be minted
   // on the destination chain given the current swap rates
   destinationNativeGas?: bigint;
@@ -211,4 +212,15 @@ export interface TransferQuote {
   warnings?: QuoteWarning[];
   // Estimated time to completion in milliseconds
   eta?: number;
+}
+
+// Information about the result of a transfer
+export interface TransferResult {
+  // How much of what token was received
+  receivedToken: {
+    token: TokenId;
+    amount: bigint;
+  }
+  // Any warnings that occurred (e.g. swap failed)
+  warnings?: TransferWarning[];
 }

--- a/connect/src/warnings.ts
+++ b/connect/src/warnings.ts
@@ -9,3 +9,9 @@ export type GovernorLimitWarning = {
 };
 
 export type QuoteWarning = DestinationCapacityWarning | GovernorLimitWarning;
+
+export type SwapFailedWarning = {
+  type: "SwapFailedWarning";
+};
+
+export type TransferWarning = SwapFailedWarning;

--- a/core/definitions/src/protocols/portico/portico.ts
+++ b/core/definitions/src/protocols/portico/portico.ts
@@ -34,6 +34,14 @@ export namespace PorticoBridge {
     relayerFee: bigint;
   };
 
+  export type TransferResult = {
+    swapResult: "success" | "failed" | "pending";
+    receivedToken?: {
+      token: TokenId;
+      amount: bigint;
+    };
+  };
+
   const _transferPayloads = ["Transfer"] as const;
   const _payloads = [..._transferPayloads] as const;
 
@@ -113,4 +121,7 @@ export interface PorticoBridge<N extends Network = Network, C extends Chain = Ch
 
   /** Get the Portico contract address for the token group */
   getPorticoAddress(group: string): string;
+
+  /** Get the transfer result on the this chain */
+  getTransferResult(vaa: PorticoBridge.VAA): Promise<PorticoBridge.TransferResult>;
 }

--- a/platforms/evm/protocols/portico/src/abis.ts
+++ b/platforms/evm/protocols/portico/src/abis.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 export const porticoAbi = new ethers.Interface([
   'function start((bytes32,address,address,address,address,address,uint256,uint256,uint256,uint256)) returns (address,uint16,uint64)',
   'function receiveMessageAndSwap(bytes)',
+  'event PorticoSwapFinish(bool swapCompleted, uint256 finaluserAmount, uint256 relayerFeeAmount, tuple(bytes32 flags, address finalTokenAddress, address recipientAddress, uint256 canonAssetAmount, uint256 minAmountFinish, uint256 relayerFee) data)',
 ]);
 
 export const porticoSwapFinishedEvent =


### PR DESCRIPTION
In addition to checking if the transfer was completed, we now check if the swap actually succeeded or failed. When the swap fails, the Wormhole-wrapped / highway token is received instead. If we can't find the swap event, then we assume it succeeded.