### PR TITLE
Include Spl Token 2022 in getBalances

### DIFF
--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -19,7 +19,7 @@ import {
 } from '@wormhole-foundation/sdk-connect';
 import { SolanaChain } from './chain.js';
 
-import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import { TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from '@solana/spl-token';
 import type {
   Commitment,
   ConnectionConfig,
@@ -157,6 +157,17 @@ export class SolanaPlatform<N extends Network>
       },
     );
 
+    // Fetch 2022 tokens
+    const splParsedToken2022Accounts = await rpc.getParsedTokenAccountsByOwner(
+      new PublicKey(walletAddress),
+      {
+        programId: new PublicKey(TOKEN_2022_PROGRAM_ID),
+      },
+    );
+
+    // Merge the two token account lists
+    splParsedTokenAccounts.value.push(...splParsedToken2022Accounts.value);
+  
     const balancesArr = tokens.map((token) => {
       if (isNative(token)) {
         return { ['native']: native };

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -21,6 +21,7 @@ import { SolanaChain } from './chain.js';
 
 import { TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from '@solana/spl-token';
 import type {
+  AccountInfo,
   Commitment,
   ConnectionConfig,
   ParsedAccountData,
@@ -150,30 +151,24 @@ export class SolanaPlatform<N extends Network>
       native = BigInt(await rpc.getBalance(new PublicKey(walletAddress)));
     }
 
-    const splParsedTokenAccounts = await rpc.getParsedTokenAccountsByOwner(
-      new PublicKey(walletAddress),
-      {
-        programId: new PublicKey(TOKEN_PROGRAM_ID),
-      },
-    );
+    const splParsedTokenAccounts = (await Promise.all(
+      [TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID]
+        .map(pid => new PublicKey(pid))
+        .map(programId => rpc.getParsedTokenAccountsByOwner(new PublicKey(walletAddress), { programId })
+        ))).reduce<{
+          pubkey: PublicKey;
+          account: AccountInfo<ParsedAccountData>;
+        }[]
+        >((acc, val) => {
+          return acc.concat(val.value);
+        }, []);
 
-    // Fetch 2022 tokens
-    const splParsedToken2022Accounts = await rpc.getParsedTokenAccountsByOwner(
-      new PublicKey(walletAddress),
-      {
-        programId: new PublicKey(TOKEN_2022_PROGRAM_ID),
-      },
-    );
-
-    // Merge the two token account lists
-    splParsedTokenAccounts.value.push(...splParsedToken2022Accounts.value);
-  
     const balancesArr = tokens.map((token) => {
       if (isNative(token)) {
         return { ['native']: native };
       }
       const addrString = new SolanaAddress(token).toString();
-      const amount = splParsedTokenAccounts.value.find(
+      const amount = splParsedTokenAccounts.find(
         (v) => v?.account.data.parsed?.info?.mint === token,
       )?.account.data.parsed?.info?.tokenAmount?.amount;
       if (!amount) return { [addrString]: null };


### PR DESCRIPTION

In LibertAI token NTT integration we saw this bug in Solana token selector:

<img width="979" alt="Captura de pantalla 2024-10-28 a la(s) 3 24 13 p m" src="https://github.com/user-attachments/assets/f966bbdf-e648-4eff-ab16-2407c615fa0c">

It shows as disabled when I have a balance in my wallet. It happens because the LibertAI token uses the program [spl token 2022](https://github.com/solana-labs/solana-program-library/blob/21f0430147686d2a948e090b358b1fbfe2d4bb03/token/js/src/constants.ts#L7), and the SDK only queries the spl token program https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/main/platforms/solana/src/platform.ts#L153-L158.

The solution we found is to include request with the spl token 2022 program id https://github.com/solana-labs/solana-program-library/blob/master/token/js/src/constants.ts#L7




