### PR TITLE
use 72 blocks for eth finality which should cover p75

### DIFF
--- a/core/base/__tests__/finality.ts
+++ b/core/base/__tests__/finality.ts
@@ -7,7 +7,7 @@ import {
 
 describe("Finality tests", function () {
   test("Receive expected number of rounds", () => {
-    expect(finalityThreshold("Ethereum")).toEqual(96);
+    expect(finalityThreshold("Ethereum")).toEqual(72);
     expect(finalityThreshold("Algorand")).toEqual(0);
     expect(finalityThreshold("Solana")).toEqual(32);
   });
@@ -41,7 +41,7 @@ describe("Finality tests", function () {
   test("Estimates rounds from finalized consistency level", () => {
     // 100 + (# final rounds)
     expect(consistencyLevelToBlock("Ethereum", ConsistencyLevels.Finalized, fromBlock)).toEqual(
-      fromBlock + 96n,
+      fromBlock + 72n,
     );
     expect(consistencyLevelToBlock("Solana", ConsistencyLevels.Finalized, fromBlock)).toEqual(
       fromBlock + 32n,

--- a/core/base/src/constants/finality.ts
+++ b/core/base/src/constants/finality.ts
@@ -26,7 +26,7 @@ export const safeThreshold = constMap(safeThresholds);
 // Number of blocks before a transaction is considered "final"
 const finalityThresholds = [
   ["Solana",   32],
-  ["Ethereum", 96],
+  ["Ethereum", 72], // between 64 and 95 blocks; use 72 as a middle ground
   ["Bsc",      15],
   // Checkpointed to L1 after ~512 blocks
   ["Optimism",  512],


### PR DESCRIPTION
finality is somewhere between 64 and 95 blocks