### PR TITLE
Remove redundant method from Route interface

### DIFF
--- a/connect/__tests__/mocks/routes/automatic.ts
+++ b/connect/__tests__/mocks/routes/automatic.ts
@@ -60,10 +60,6 @@ export class AutomaticMockRoute<N extends Network>
     return [nativeTokenId(toChain.chain)];
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
-    return true;
-  }
-
   async validate(
     request: RouteTransferRequest<N>,
     params: TransferParams<Op>,

--- a/connect/__tests__/mocks/routes/manual.ts
+++ b/connect/__tests__/mocks/routes/manual.ts
@@ -58,10 +58,6 @@ export class ManualMockRoute<N extends Network>
     return [nativeTokenId(toChain.chain)];
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
-    return true;
-  }
-
   async validate(
     request: RouteTransferRequest<N>,
     params: TransferParams<Op>,

--- a/connect/src/routes/cctp/automatic.ts
+++ b/connect/src/routes/cctp/automatic.ts
@@ -100,10 +100,6 @@ export class AutomaticCCTPRoute<N extends Network>
     return [Wormhole.chainAddress(chain, circle.usdcContract.get(network, chain)!)];
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
-    return chain.supportsAutomaticCircleBridge();
-  }
-
   getDefaultOptions(): Op {
     return {
       nativeGas: 0.0,

--- a/connect/src/routes/cctp/manual.ts
+++ b/connect/src/routes/cctp/manual.ts
@@ -93,10 +93,6 @@ export class CCTPRoute<N extends Network>
     return [Wormhole.chainAddress(chain, circle.usdcContract.get(network, chain)!)];
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
-    return chain.supportsCircleBridge();
-  }
-
   getDefaultOptions(): Op {
     return {
       payload: undefined,

--- a/connect/src/routes/portico/automatic.ts
+++ b/connect/src/routes/portico/automatic.ts
@@ -140,10 +140,6 @@ export class AutomaticPorticoRoute<N extends Network>
       .map((t) => t.token);
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
-    return chain.supportsPorticoBridge();
-  }
-
   getDefaultOptions(): OP {
     return {};
   }
@@ -151,8 +147,8 @@ export class AutomaticPorticoRoute<N extends Network>
   async validate(request: RouteTransferRequest<N>, params: TP): Promise<VR> {
     try {
       if (
-        !AutomaticPorticoRoute.isProtocolSupported(request.fromChain) ||
-        !AutomaticPorticoRoute.isProtocolSupported(request.toChain)
+        !AutomaticPorticoRoute.supportedChains(request.fromChain.network).includes(request.fromChain.chain) ||
+        !AutomaticPorticoRoute.supportedChains(request.toChain.network).includes(request.toChain.chain)
       ) {
         throw new Error("Protocol not supported");
       }

--- a/connect/src/routes/resolver.ts
+++ b/connect/src/routes/resolver.ts
@@ -62,9 +62,7 @@ export class RouteResolver<N extends Network> {
           const protocolSupported =
             rc.supportedNetworks().includes(this.wh.network) &&
             rc.supportedChains(this.wh.network).includes(request.toChain.chain) &&
-            rc.supportedChains(this.wh.network).includes(request.fromChain.chain) &&
-            rc.isProtocolSupported(request.fromChain) &&
-            rc.isProtocolSupported(request.toChain);
+            rc.supportedChains(this.wh.network).includes(request.fromChain.chain)
 
           const sourceTokenAddress = canonicalAddress(
             isNative(request.source.id.address) ? request.source.wrapped! : request.source.id,

--- a/connect/src/routes/route.ts
+++ b/connect/src/routes/route.ts
@@ -87,8 +87,6 @@ export interface RouteConstructor<OP extends Options = Options> {
   supportedNetworks(): Network[];
   /** get the list of chains this route supports */
   supportedChains(network: Network): Chain[];
-  /** check that the underlying protocols are supported */
-  isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean;
   /** get the list of source tokens that are possible to send */
   supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]>;
   /** get the list of destination tokens that may be received on the destination chain */

--- a/connect/src/routes/tokenBridge/automatic.ts
+++ b/connect/src/routes/tokenBridge/automatic.ts
@@ -111,10 +111,6 @@ export class AutomaticTokenBridgeRoute<N extends Network>
     }
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
-    return chain.supportsAutomaticTokenBridge();
-  }
-
   getDefaultOptions(): Op {
     return { nativeGas: 0.0 };
   }

--- a/connect/src/routes/tokenBridge/manual.ts
+++ b/connect/src/routes/tokenBridge/manual.ts
@@ -89,10 +89,6 @@ export class TokenBridgeRoute<N extends Network>
     }
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
-    return chain.supportsTokenBridge();
-  }
-
   getDefaultOptions(): Op {
     return { payload: undefined };
   }

--- a/scripts/src/features.ts
+++ b/scripts/src/features.ts
@@ -65,7 +65,7 @@ function getSupportmatrix(n: Network) {
     for (const chain of chains) {
       try {
         const ctx = wh.getChain(chain as Chain);
-        protoSupport[name]![chain] = rc.isProtocolSupported(ctx);
+        protoSupport[name]![chain] = rc.supportedChains(ctx.network).includes(ctx.chain);
       } catch (e) {
         console.log("error on: ", chain);
       }


### PR DESCRIPTION
`isProtocolSupported` is redundant with `supportedChains`. We should keep the `Route` interface as small as possible to make it easy for plugins to be written. This reduces up the interface to four consistent methods, which I think is cleaner:

```ts
  supportedNetworks(): Network[];

  supportedChains(network: Network): Chain[];

  supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]>;

  supportedDestinationTokens<N extends Network>(
    token: TokenId,
    fromChain: ChainContext<N>,
    toChain: ChainContext<N>,
  ): Promise<TokenId[]>;
```