### PR TITLE
Update Monad devnet core address

### DIFF
--- a/core/base/src/constants/contracts/core.ts
+++ b/core/base/src/constants/contracts/core.ts
@@ -91,7 +91,7 @@ export const coreBridgeContracts = [[
     ["Ink",             "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"],
     ["Xlayer",          "0xA31aa3FDb7aF7Db93d18DDA4e19F811342EDF780"],
     ["Linea",           "0x79A1027a6A159502049F10906D333EC57E95F083"],
-    ["MonadDevnet",     "0x376428e7f26D5867e69201b275553C45B09EE090"],
+    ["MonadDevnet",     "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"],
   ]], [
   "Devnet", [
     ["Solana",    "Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"],


### PR DESCRIPTION
The core contract is now available [here](https://brightstar-884.devnet1.monad.xyz/address/0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd).