### PR TITLE
portico: pass portico bridge instance instead of destination address

### DIFF
--- a/connect/src/routes/portico/automatic.ts
+++ b/connect/src/routes/portico/automatic.ts
@@ -272,9 +272,7 @@ export class AutomaticPorticoRoute<N extends Network>
     const destToken = request.destination!.id;
 
     const fromPorticoBridge = await request.fromChain.getPorticoBridge();
-    const tokenGroup = fromPorticoBridge.getTokenGroup(sourceToken.toString());
     const toPorticoBridge = await request.toChain.getPorticoBridge();
-    const destPorticoAddress = toPorticoBridge.getPorticoAddress(tokenGroup);
 
     const xfer = fromPorticoBridge.transfer(
       Wormhole.parseAddress(sender.chain(), sender.address()),
@@ -282,7 +280,7 @@ export class AutomaticPorticoRoute<N extends Network>
       sourceToken,
       amount.units(params.normalizedParams.amount),
       destToken!,
-      destPorticoAddress,
+      toPorticoBridge,
       details!,
     );
 

--- a/core/definitions/src/protocols/portico/portico.ts
+++ b/core/definitions/src/protocols/portico/portico.ts
@@ -81,7 +81,7 @@ export interface PorticoBridge<N extends Network = Network, C extends Chain = Ch
     token: TokenAddress<C>,
     amount: bigint,
     destToken: TokenId,
-    destPorticoAddress: string,
+    toPorticoBridge: PorticoBridge<N>,
     quote: PorticoBridge.Quote,
   ): AsyncGenerator<UnsignedTransaction<N, C>>;
 
@@ -113,4 +113,6 @@ export interface PorticoBridge<N extends Network = Network, C extends Chain = Ch
 
   /** Get the Portico contract address for the token group */
   getPorticoAddress(group: string): string;
+
+  getChain(): Chain;
 }

--- a/platforms/evm/protocols/portico/src/bridge.ts
+++ b/platforms/evm/protocols/portico/src/bridge.ts
@@ -87,9 +87,22 @@ export class EvmPorticoBridge<
     token: TokenAddress<C>,
     amount: bigint,
     destToken: TokenId,
-    destinationPorticoAddress: string,
+    toPorticoBridge: PorticoBridge<N>,
     quote: PorticoBridge.Quote,
   ) {
+    const toChain = toPorticoBridge.getChain();
+    if (this.chain === toChain) {
+      throw new Error('Cannot transfer to the same chain');
+    }
+
+    if (receiver.chain !== toChain) {
+      throw new Error('Invalid destination chain');
+    }
+
+    const tokenGroup = this.getTokenGroup(token.toString());
+    const destinationPorticoAddress =
+      toPorticoBridge.getPorticoAddress(tokenGroup);
+
     const { minAmountStart, minAmountFinish } = quote.swapAmounts;
     if (minAmountStart === 0n) throw new Error('Invalid min swap amount');
     if (minAmountFinish === 0n) throw new Error('Invalid min swap amount');
@@ -294,6 +307,10 @@ export class EvmPorticoBridge<
     const token = tokens.find((t) => canonicalAddress(t.token) === address);
     if (!token) throw new Error('Token not found');
     return token.group;
+  }
+
+  getChain() {
+    return this.chain;
   }
 
   private async *approve(


### PR DESCRIPTION
makes it harder to misuse the interface and pass a wrong address