### PR TITLE
Make sure both chains are supported

### DIFF
--- a/connect/src/routes/resolver.ts
+++ b/connect/src/routes/resolver.ts
@@ -44,6 +44,11 @@ export class RouteResolver<N extends Network> {
     const [, inputTokenId] = resolveWrappedToken(fromChain.network, fromChain.chain, inputToken);
     const tokens = await Promise.all(
       this.routeConstructors.map(async (rc) => {
+        const supportedChains = rc.supportedChains(fromChain.network);
+        if (!supportedChains.includes(fromChain.chain) || !supportedChains.includes(toChain.chain)) {
+          return [];
+        }
+
         try {
           return await rc.supportedDestinationTokens(inputTokenId, fromChain, toChain);
         } catch (e) {

--- a/connect/src/routes/resolver.ts
+++ b/connect/src/routes/resolver.ts
@@ -44,6 +44,11 @@ export class RouteResolver<N extends Network> {
     const [, inputTokenId] = resolveWrappedToken(fromChain.network, fromChain.chain, inputToken);
     const tokens = await Promise.all(
       this.routeConstructors.map(async (rc) => {
+        const supportedNetworks = rc.supportedNetworks();
+        if (!supportedNetworks.includes(fromChain.network)) {
+          return [];
+        }
+
         const supportedChains = rc.supportedChains(fromChain.network);
         if (!supportedChains.includes(fromChain.chain) || !supportedChains.includes(toChain.chain)) {
           return [];


### PR DESCRIPTION
If a route fails to properly check the chains in `supportedDestinationTokens` as [the Mayan route does right now (oops)](https://github.com/mayan-finance/wormhole-sdk-route/blob/main/src/index.ts#L122) then this will be a helpful fallback.