### PR TITLE
docs: Fixed Typo in Code Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ See the testing signers ([Evm](https://github.com/wormhole-foundation/connect-sd
 
 Working with VAAs directly may be necessary. The SDK includes an entire layouting package to define the structure of a VAA payload and provides the ability to easily serialize and deserialize the VAAs or VAA payloads.
 
-Using `Uint8Array` as the paylaod type will always work:
+Using `Uint8Array` as the payload type will always work:
 <!--EXAMPLE_PARSE_VAA-->
 ```ts
   // Create a fake vaa and serialize it to bytes


### PR DESCRIPTION
<img width="472" alt="Снимок экрана 2024-12-08 в 15 20 17" src="https://github.com/user-attachments/assets/ae17476a-4946-496c-ac9a-bfd2c3b8da0c">

The word "paylaod" was used instead of "payload." This could potentially cause confusion for readers, especially since "payload" is a commonly used term in the context of data serialization and messaging.

This change helps maintain the integrity of the documentation and avoids any possible misunderstandings.

Thanks for Wormhole!