### PR TITLE
Ensure token address is a string

### DIFF
--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -169,7 +169,7 @@ export class SolanaPlatform<N extends Network>
       }
       const addrString = new SolanaAddress(token).toString();
       const amount = splParsedTokenAccounts.find(
-        (v) => v?.account.data.parsed?.info?.mint === token,
+        (v) => v?.account.data.parsed?.info?.mint === token.toString(),
       )?.account.data.parsed?.info?.tokenAmount?.amount;
       if (!amount) return { [addrString]: null };
       return { [addrString]: BigInt(amount) };


### PR DESCRIPTION
This function has a bug: it accepts type `AnySolanaAddress[]` where `AnySolanaAddress` is either a Solana `NativeAddress` or a [`PublicKeyInitData` from web3.js](https://solana-labs.github.io/solana-web3.js/v1.x/types/PublicKeyInitData.html) which can be a string... but then it assumes it's working with a string in this equality check because the RPC response `account.data.parsed?.info?.mint` is a string.

This change ensures that we are indeed comparing a string to a string.