### PR TITLE
Add gasLimit option to EvmSignerOptions for overriding gas limit

### DIFF
--- a/platforms/evm/src/signer.ts
+++ b/platforms/evm/src/signer.ts
@@ -23,6 +23,8 @@ import { _platform } from './types.js';
 export type EvmSignerOptions = {
   // Whether or not to log messages
   debug?: boolean;
+  // Override gas limit
+  gasLimit?: bigint;
   // Do not exceed this gas limit
   maxGasLimit?: bigint;
   // Partially override specific transaction request fields
@@ -115,6 +117,10 @@ export class EvmNativeSigner<N extends Network, C extends EvmChains = EvmChains>
         maxPriorityFeePerGas =
           feeData.maxPriorityFeePerGas ?? maxPriorityFeePerGas;
       }
+    }
+
+    if (this.opts?.gasLimit !== undefined) {
+      gasLimit = this.opts.gasLimit;
     }
 
     if (this.opts?.maxGasLimit !== undefined) {


### PR DESCRIPTION
The EVM signer's gas limit is hardcoded to 500,000, which is insufficient for chains like Arbitrum in some cases. 
- Failed with 50w gas, https://arbiscan.io/tx/0xa52ff890d9e43ba316c43fb357800bed0b7b59ef9f3143b1514f4a8b79812f5e
- Extremely high with 51,881,506 gas  https://arbiscan.io/tx/0xe3fa9f5201a3c9b1fe3d709e3add4b17a633639d5b8f280f9c05c4e6cef2a192

We need to provide the ability to modify the gas limit in EvmSignerOptions.

Dune query:
`
select *
from arbitrum.transactions
where to = 0x0b2402144Bb366A632D14B83F244D2e0e21bD39c
order by gas_used desc
limit 100
`