### PR TITLE
aptos: migrate sdk to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -212,16 +212,106 @@
         }
       }
     },
-    "node_modules/@aptos-labs/aptos-client": {
-      "version": "0.1.0",
+    "node_modules/@aptos-labs/aptos-cli": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-cli/-/aptos-cli-1.0.2.tgz",
+      "integrity": "sha512-PYPsd0Kk3ynkxNfe3S4fanI3DiUICCoh4ibQderbvjPFL5A0oK6F4lPEO2t0MDsQySTk2t4vh99Xjy6Bd9y+aQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "1.6.2",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "aptos": "dist/aptos.js"
+      }
+    },
+    "node_modules/@aptos-labs/aptos-cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@aptos-labs/aptos-client": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.1.1.tgz",
+      "integrity": "sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "1.7.4",
         "got": "^11.8.6"
       },
       "engines": {
         "node": ">=15.10.0"
       }
+    },
+    "node_modules/@aptos-labs/ts-sdk": {
+      "version": "1.33.1",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.33.1.tgz",
+      "integrity": "sha512-d6nWtUI//fyEN8DeLjm3+ro87Ad6+IKwR9pCqfrs/Azahso1xR1Llxd/O6fj/m1DDsuDj/HAsCsy5TC/aKD6Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aptos-labs/aptos-cli": "^1.0.2",
+        "@aptos-labs/aptos-client": "^0.1.1",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "@scure/bip32": "^1.4.0",
+        "@scure/bip39": "^1.3.0",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
+        "js-base64": "^3.7.7",
+        "jwt-decode": "^4.0.0",
+        "poseidon-lite": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
@@ -1476,16 +1566,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@injectivelabs/sdk-ts/node_modules/bech32": {
       "version": "2.0.0",
       "license": "MIT"
@@ -1502,16 +1582,6 @@
         "shx": "^0.3.2",
         "snakecase-keys": "^5.1.2",
         "store2": "^2.12.0"
-      }
-    },
-    "node_modules/@injectivelabs/test-utils/node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@injectivelabs/ts-types": {
@@ -1539,16 +1609,6 @@
         "shx": "^0.3.2",
         "snakecase-keys": "^5.1.2",
         "store2": "^2.12.0"
-      }
-    },
-    "node_modules/@injectivelabs/utils/node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2142,50 +2202,87 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@scure/base": {
-      "version": "1.1.5",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
+      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.3.3",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.0.tgz",
+      "integrity": "sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.3.0",
-        "@noble/hashes": "~1.3.2",
-        "@scure/base": "~1.1.4"
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "1.3.0",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.3.3"
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "1.3.3",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.2.2",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.0.tgz",
+      "integrity": "sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.3.2",
-        "@scure/base": "~1.1.4"
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2198,6 +2295,8 @@
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2362,6 +2461,8 @@
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
@@ -2444,6 +2545,8 @@
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
@@ -2489,6 +2592,8 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -2534,6 +2639,8 @@
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2571,6 +2678,8 @@
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3142,46 +3251,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/aptos": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aptos-labs/aptos-client": "^0.1.0",
-        "@noble/hashes": "1.3.3",
-        "@scure/bip39": "1.2.1",
-        "eventemitter3": "^5.0.1",
-        "form-data": "4.0.0",
-        "tweetnacl": "1.0.3"
-      },
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
-    "node_modules/aptos/node_modules/@noble/hashes": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/aptos/node_modules/@scure/bip39": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/aptos/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "license": "MIT"
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
@@ -3221,10 +3290,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.6.2",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -3597,6 +3668,8 @@
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
@@ -3604,6 +3677,8 @@
     },
     "node_modules/cacheable-request": {
       "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -3620,6 +3695,8 @@
     },
     "node_modules/cacheable-request/node_modules/get-stream": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -3809,6 +3886,8 @@
     },
     "node_modules/clone-response": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -4013,6 +4092,8 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -4026,6 +4107,8 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4074,6 +4157,8 @@
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4230,6 +4315,8 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -5032,6 +5119,8 @@
     },
     "node_modules/got": {
       "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -5242,6 +5331,8 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/http-status-codes": {
@@ -5251,6 +5342,8 @@
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -5262,6 +5355,8 @@
     },
     "node_modules/http2-wrapper/node_modules/quick-lru": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6156,6 +6251,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-sha256": {
       "version": "0.9.0",
       "license": "MIT"
@@ -6270,6 +6371,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keccak": {
@@ -6503,6 +6613,8 @@
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6674,6 +6786,8 @@
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6973,6 +7087,8 @@
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7066,6 +7182,8 @@
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7294,6 +7412,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/poseidon-lite": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.2.1.tgz",
+      "integrity": "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -7403,7 +7527,9 @@
       "license": "MIT"
     },
     "node_modules/pump": {
-      "version": "3.0.0",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -7670,6 +7796,8 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "license": "MIT"
     },
     "node_modules/resolve-cwd": {
@@ -7725,6 +7853,8 @@
     },
     "node_modules/responselike": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
@@ -9025,8 +9155,8 @@
       "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "aptos": "1.21.0"
+        "@aptos-labs/ts-sdk": "^1.33.1",
+        "@wormhole-foundation/sdk-connect": "1.0.3"
       },
       "engines": {
         "node": ">=16"

--- a/platforms/aptos/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/aptos/__tests__/integration/tokenBridge.test.ts
@@ -163,7 +163,7 @@ describe("TokenBridge Tests", () => {
       expect(attestTx!.chain).toEqual(chain);
 
       const { transaction } = attestTx!;
-      expect(transaction.arguments).toHaveLength(0);
+      expect(transaction.functionArguments).toHaveLength(0);
     });
 
     test("Submit Attestation", async () => {
@@ -223,7 +223,7 @@ describe("TokenBridge Tests", () => {
           expect(xferTx!.chain).toEqual(chain);
 
           const { transaction } = xferTx!;
-          expect(transaction.arguments).toHaveLength(5);
+          expect(transaction.functionArguments).toHaveLength(5);
           // ...
         });
 
@@ -242,8 +242,8 @@ describe("TokenBridge Tests", () => {
           expect(xferTx!.chain).toEqual(chain);
 
           const { transaction } = xferTx!;
-          expect(transaction.type_arguments).toHaveLength(1);
-          expect(transaction.arguments).toHaveLength(5);
+          expect(transaction.typeArguments).toHaveLength(1);
+          expect(transaction.functionArguments).toHaveLength(5);
         });
       });
     });

--- a/platforms/aptos/__tests__/unit/platform.test.ts
+++ b/platforms/aptos/__tests__/unit/platform.test.ts
@@ -6,7 +6,7 @@ import { AptosChains, AptosPlatform } from "./../../src/index.js";
 
 import "@wormhole-foundation/sdk-aptos-core";
 import "@wormhole-foundation/sdk-aptos-tokenbridge";
-import { AptosClient } from "aptos";
+import { Aptos, AptosConfig, Network as AptosNetwork } from "@aptos-labs/ts-sdk";
 
 const network = DEFAULT_NETWORK;
 
@@ -22,7 +22,11 @@ describe("Aptos Platform Tests", () => {
         [APTOS_CHAINS[0]!]: configs[APTOS_CHAINS[0]!],
       });
 
-      const client = new AptosClient(configs[APTOS_CHAINS[0]!]!.rpc);
+      const config = new AptosConfig({
+        fullnode: configs[APTOS_CHAINS[0]!]!.rpc,
+        network: AptosNetwork.MAINNET,
+      });
+      const client = new Aptos(config);
       const tb = await p.getProtocol("TokenBridge", client);
       expect(tb).toBeTruthy();
     });

--- a/platforms/aptos/package.json
+++ b/platforms/aptos/package.json
@@ -46,8 +46,8 @@
     "prettier": "prettier --write ./src"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-connect": "1.0.3",
-    "aptos": "1.21.0"
+    "@aptos-labs/ts-sdk": "^1.33.1",
+    "@wormhole-foundation/sdk-connect": "1.0.3"
   },
   "type": "module",
   "typesVersions": {

--- a/platforms/aptos/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/aptos/protocols/tokenBridge/src/tokenBridge.ts
@@ -35,9 +35,9 @@ import {
   coalesceModuleAddress,
   isValidAptosType,
 } from "@wormhole-foundation/sdk-aptos";
-import type { AptosClient, Types } from "aptos";
 import { serializeForeignAddressSeeds } from "./foreignAddress.js";
 import type { OriginInfo, TokenBridgeState } from "./types.js";
+import { Aptos, InputGenerateTransactionPayloadData } from "@aptos-labs/ts-sdk";
 
 export class AptosTokenBridge<N extends Network, C extends AptosChains>
   implements TokenBridge<N, C>
@@ -48,7 +48,7 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
   constructor(
     readonly network: N,
     readonly chain: C,
-    readonly connection: AptosClient,
+    readonly connection: Aptos,
     readonly contracts: Contracts,
   ) {
     this.chainId = toChainId(chain);
@@ -60,7 +60,7 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
   }
 
   static async fromRpc<N extends Network>(
-    connection: AptosClient,
+    connection: Aptos,
     config: ChainsConfig<N, AptosPlatformType>,
   ): Promise<AptosTokenBridge<N, AptosChains>> {
     const [network, chain] = await AptosPlatform.chainFromRpc(connection);
@@ -81,14 +81,11 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
 
   async getOriginalAsset(token: AnyAptosAddress): Promise<TokenId> {
     const fqt = token.toString().split(APTOS_SEPARATOR);
-    let originInfo: OriginInfo | undefined;
 
-    originInfo = (
-      await this.connection.getAccountResource(
-        fqt[0]!,
-        `${this.tokenBridgeAddress}::state::OriginInfo`,
-      )
-    ).data as OriginInfo;
+    const originInfo = await this.connection.getAccountResource<OriginInfo>({
+      accountAddress: fqt[0]!,
+      resourceType: `${this.tokenBridgeAddress}::state::OriginInfo`,
+    });
 
     if (!originInfo) throw ErrNotWrapped(token.toString());
 
@@ -131,32 +128,33 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
     if (!assetFullyQualifiedType) throw new Error("Invalid asset address.");
 
     // check to see if we can get origin info from asset address
-    await this.connection.getAccountResource(
-      coalesceModuleAddress(assetFullyQualifiedType),
-      `${this.tokenBridgeAddress}::state::OriginInfo`,
-    );
+    await this.connection.getAccountResource({
+      accountAddress: coalesceModuleAddress(assetFullyQualifiedType),
+      resourceType: `${this.tokenBridgeAddress}::state::OriginInfo`,
+    });
 
     // if successful, we can just return the computed address
     return toNative(this.chain, assetFullyQualifiedType);
   }
 
   async isTransferCompleted(vaa: TokenBridge.TransferVAA): Promise<boolean> {
-    const state = (
-      await this.connection.getAccountResource(
-        this.tokenBridgeAddress,
-        `${this.tokenBridgeAddress}::state::State`,
-      )
-    ).data as TokenBridgeState;
+    const state = await this.connection.getAccountResource<TokenBridgeState>({
+      accountAddress: this.tokenBridgeAddress,
+      resourceType: `${this.tokenBridgeAddress}::state::State`,
+    });
 
     const handle = state.consumed_vaas.elems.handle;
 
     // check if vaa hash is in consumed_vaas
     try {
       // when accessing Set<T>, key is type T and value is 0
-      await this.connection.getTableItem(handle, {
-        key_type: "vector<u8>",
-        value_type: "u8",
-        key: `0x${Buffer.from(keccak256(vaa.hash)).toString("hex")}`,
+      await this.connection.getTableItem({
+        handle,
+        data: {
+          key_type: "vector<u8>",
+          value_type: "u8",
+          key: `0x${Buffer.from(keccak256(vaa.hash)).toString("hex")}`,
+        },
       });
       return true;
     } catch {
@@ -179,8 +177,8 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
     yield this.createUnsignedTx(
       {
         function: `${this.tokenBridgeAddress}::attest_token::attest_token_entry`,
-        type_arguments: [assetType],
-        arguments: [],
+        typeArguments: [assetType],
+        functionArguments: [],
       },
       "Aptos.AttestToken",
     );
@@ -193,8 +191,8 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
     yield this.createUnsignedTx(
       {
         function: `${this.tokenBridgeAddress}::wrapped::create_wrapped_coin_type`,
-        type_arguments: [],
-        arguments: [serialize(vaa)],
+        typeArguments: [],
+        functionArguments: [serialize(vaa)],
       },
       "Aptos.CreateWrappedCoinType",
     );
@@ -205,8 +203,8 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
     yield this.createUnsignedTx(
       {
         function: `${this.tokenBridgeAddress}::wrapped::create_wrapped_coin`,
-        type_arguments: [assetType],
-        arguments: [serialize(vaa)],
+        typeArguments: [assetType],
+        functionArguments: [serialize(vaa)],
       },
       "Aptos.CreateWrappedCoin",
     );
@@ -230,8 +228,8 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
       yield this.createUnsignedTx(
         {
           function: `${this.tokenBridgeAddress}::transfer_tokens::transfer_tokens_with_payload_entry`,
-          type_arguments: [fullyQualifiedType],
-          arguments: [amount, dstChain, dstAddress, nonce, payload],
+          typeArguments: [fullyQualifiedType],
+          functionArguments: [amount, dstChain, dstAddress, nonce, payload],
         },
         "Aptos.TransferTokensWithPayload",
       );
@@ -239,8 +237,8 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
       yield this.createUnsignedTx(
         {
           function: `${this.tokenBridgeAddress}::transfer_tokens::transfer_tokens_entry`,
-          type_arguments: [fullyQualifiedType],
-          arguments: [amount, dstChain, dstAddress, fee, nonce],
+          typeArguments: [fullyQualifiedType],
+          functionArguments: [amount, dstChain, dstAddress, fee, nonce],
         },
         "Aptos.TransferTokens",
       );
@@ -262,8 +260,8 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
     yield this.createUnsignedTx(
       {
         function: `${this.tokenBridgeAddress}::complete_transfer::submit_vaa_and_register_entry`,
-        type_arguments: [assetType],
-        arguments: [serialize(vaa)],
+        typeArguments: [assetType],
+        functionArguments: [serialize(vaa)],
       },
       "Aptos.CompleteTransfer",
     );
@@ -296,19 +294,20 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
   async getTypeFromExternalAddress(address: string): Promise<string | null> {
     try {
       // get handle
-      const state = (
-        await this.connection.getAccountResource(
-          this.tokenBridgeAddress,
-          `${this.tokenBridgeAddress}::state::State`,
-        )
-      ).data as TokenBridgeState;
+      const state = await this.connection.getAccountResource<TokenBridgeState>({
+        accountAddress: this.tokenBridgeAddress,
+        resourceType: `${this.tokenBridgeAddress}::state::State`,
+      });
       const { handle } = state.native_infos;
 
       // get type info
-      const typeInfo = await this.connection.getTableItem(handle, {
-        key_type: `${this.tokenBridgeAddress}::token_hash::TokenHash`,
-        value_type: "0x1::type_info::TypeInfo",
-        key: { hash: address },
+      const typeInfo: any = await this.connection.getTableItem({
+        handle,
+        data: {
+          key_type: `${this.tokenBridgeAddress}::token_hash::TokenHash`,
+          value_type: "0x1::type_info::TypeInfo",
+          key: { hash: address },
+        },
       });
 
       return typeInfo
@@ -346,7 +345,7 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
   }
 
   private createUnsignedTx(
-    txReq: Types.EntryFunctionPayload,
+    txReq: InputGenerateTransactionPayloadData,
     description: string,
     parallelizable: boolean = false,
   ): AptosUnsignedTransaction<N, C> {

--- a/platforms/aptos/protocols/tokenBridge/src/types.ts
+++ b/platforms/aptos/protocols/tokenBridge/src/types.ts
@@ -1,4 +1,20 @@
-import type { TokenTypes } from "aptos";
+export interface TokenDataId {
+  /** Token creator address */
+  creator: string;
+
+  /** Unique name within this creator's account for this Token's collection */
+  collection: string;
+
+  /** Name of Token */
+  name: string;
+}
+
+export interface TokenId {
+  token_data_id: TokenDataId;
+
+  /** version number of the property map */
+  property_version: string;
+}
 
 export type TokenBridgeState = {
   consumed_vaas: {
@@ -49,7 +65,7 @@ export type CreateTokenDataEvent = {
   type: "0x3::token::CreateTokenDataEvent";
   data: {
     description: string;
-    id: TokenTypes.TokenDataId;
+    id: TokenDataId;
     maximum: string;
     mutability_config: {
       description: boolean;
@@ -79,6 +95,6 @@ export type DepositEvent = {
   type: "0x3::token::DepositEvent";
   data: {
     amount: string;
-    id: TokenTypes.TokenId;
+    id: TokenId;
   };
 };

--- a/platforms/aptos/src/unsignedTransaction.ts
+++ b/platforms/aptos/src/unsignedTransaction.ts
@@ -1,12 +1,12 @@
 import type { Network, UnsignedTransaction } from "@wormhole-foundation/sdk-connect";
-import type { Types } from "aptos";
+import type { InputGenerateTransactionPayloadData } from "@aptos-labs/ts-sdk";
 import type { AptosChains } from "./types.js";
 
 export class AptosUnsignedTransaction<N extends Network, C extends AptosChains>
   implements UnsignedTransaction<N, C>
 {
   constructor(
-    readonly transaction: Types.EntryFunctionPayload,
+    readonly transaction: InputGenerateTransactionPayloadData,
     readonly network: N,
     readonly chain: C,
     readonly description: string,


### PR DESCRIPTION
use @aptos-labs/ts-sdk instead of deprecated aptos package