### PR TITLE
Update ETH testnet to sepolia from goerli

### DIFF
--- a/core/base/src/constants/rpc.ts
+++ b/core/base/src/constants/rpc.ts
@@ -50,7 +50,7 @@ const rpcConfig = [[
     ["Worldchain","https://worldchain-mainnet.g.alchemy.com/public"],
   ]], [
   "Testnet", [
-    ["Ethereum",        "https://eth-goerli.public.blastapi.io"],
+    ["Ethereum",        "https://eth-sepolia.public.blastapi.io"],
     ["Polygon",         "https://rpc-mumbai.polygon.technology"],
     ["Bsc",             "https://data-seed-prebsc-1-s3.binance.org:8545"],
     ["Avalanche",       "https://api.avax-test.network/ext/bc/C/rpc"],


### PR DESCRIPTION
Goerli testnet is deprecated, and the URL no longer works. This change updates the testnet RPC endpoint to the sepolia testnet

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wormhole-foundation/wormhole-sdk-ts/pull/783?shareId=193f2ebe-0bb2-49a1-8847-6425ed9164b3).