### PR TITLE
Add Unichain mainnet support

### DIFF
--- a/core/base/src/constants/contracts/core.ts
+++ b/core/base/src/constants/contracts/core.ts
@@ -40,6 +40,7 @@ export const coreBridgeContracts = [[
     ["Scroll",    "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"],
     ["Mantle",    "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"],
     ["Snaxchain", "0xc1BA3CC4bFE724A08FbbFbF64F8db196738665f4"],
+    ["Unichain",  "0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"],
     ["Worldchain","0xcbcEe4e081464A15d8Ad5f58BB493954421eB506"],
   ]], [
   "Testnet", [

--- a/core/base/src/constants/contracts/tokenBridge.ts
+++ b/core/base/src/constants/contracts/tokenBridge.ts
@@ -36,6 +36,7 @@ export const tokenBridgeContracts = [[
     ["Scroll",    "0x24850c6f61C438823F01B7A3BF2B89B72174Fa9d"],
     ["Mantle",    "0x24850c6f61C438823F01B7A3BF2B89B72174Fa9d"],
     ["Snaxchain", "0x8B94bfE456B48a6025b92E11Be393BAa86e68410"],
+    ["Unichain",  "0x3Ff72741fd67D6AD0668d93B41a09248F4700560"],
     ["Worldchain","0xc309275443519adca74c9136b02A38eF96E3a1f6"],
   ]], [
   "Testnet", [

--- a/core/base/src/constants/nativeChainIds.ts
+++ b/core/base/src/constants/nativeChainIds.ts
@@ -55,6 +55,7 @@ const chainNetworkNativeChainIdEntries = [
       ["Blast",     81457n],
       ["Linea",     59144n],
       ["Snaxchain", 2192n],
+      ["Unichain",  130n],
       ["Worldchain",480n],
     ],
   ],

--- a/core/base/src/constants/rpc.ts
+++ b/core/base/src/constants/rpc.ts
@@ -47,6 +47,7 @@ const rpcConfig = [[
     ["Mantle",    "https://rpc.mantle.xyz"],
     ["Klaytn",    "https://rpc.ankr.com/klaytn"],
     ["Snaxchain", "https://mainnet.snaxchain.io"],
+    ["Unichain",  "https://mainnet.unichain.org"],
     ["Worldchain","https://worldchain-mainnet.g.alchemy.com/public"],
   ]], [
   "Testnet", [


### PR DESCRIPTION
The core is available [here](https://unichain-d7a86fxp.blockscout.com/address/0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D).

The token bridge is available [here](https://unichain-d7a86fxp.blockscout.com/address/0x3Ff72741fd67D6AD0668d93B41a09248F4700560).