### PR TITLE
Add Ink mainnet support

### DIFF
--- a/core/base/src/constants/contracts/core.ts
+++ b/core/base/src/constants/contracts/core.ts
@@ -42,6 +42,7 @@ export const coreBridgeContracts = [[
     ["Berachain", "0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"],
     ["Unichain",  "0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"],
     ["Worldchain","0xcbcEe4e081464A15d8Ad5f58BB493954421eB506"],
+    ["Ink",       "0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"],
   ]], [
   "Testnet", [
     ["Solana",          "3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5"],

--- a/core/base/src/constants/contracts/tokenBridge.ts
+++ b/core/base/src/constants/contracts/tokenBridge.ts
@@ -39,6 +39,7 @@ export const tokenBridgeContracts = [[
     ["Berachain", "0x3Ff72741fd67D6AD0668d93B41a09248F4700560"],
     ["Unichain",  "0x3Ff72741fd67D6AD0668d93B41a09248F4700560"],
     ["Worldchain","0xc309275443519adca74c9136b02A38eF96E3a1f6"],
+    ["Ink",       "0x3Ff72741fd67D6AD0668d93B41a09248F4700560"],
   ]], [
   "Testnet", [
     ["Solana",          "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe"],

--- a/core/base/src/constants/finality.ts
+++ b/core/base/src/constants/finality.ts
@@ -136,6 +136,7 @@ const blockTimeMilliseconds = [
   ["Xpla",              5_000],
   ["Xlayer",            3_000],
   ["Worldchain",        2_000],
+  ["Ink",               1_000],
   ["Wormchain",         5_000],
   ["Btc",             600_000],
   ["Pythnet",             400],

--- a/core/base/src/constants/nativeChainIds.ts
+++ b/core/base/src/constants/nativeChainIds.ts
@@ -57,6 +57,7 @@ const chainNetworkNativeChainIdEntries = [
       ["Berachain", 80094n],
       ["Unichain",  130n],
       ["Worldchain",480n],
+      ["Ink",       57073n],
     ],
   ],
   [

--- a/core/base/src/constants/rpc.ts
+++ b/core/base/src/constants/rpc.ts
@@ -49,6 +49,7 @@ const rpcConfig = [[
     ["Berachain", "https://rpc.berachain.com"],
     ["Unichain",  "https://mainnet.unichain.org"],
     ["Worldchain","https://worldchain-mainnet.g.alchemy.com/public"],
+    ["Ink",       "https://rpc-qnd.inkonchain.com"],
   ]], [
   "Testnet", [
     ["Ethereum",        "https://eth-sepolia.public.blastapi.io"],


### PR DESCRIPTION
This PR enabled Ink in mainnet.

- The core is available [here](https://explorer.inkonchain.com/address/0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D).
- The token bridge is available [here](https://explorer.inkonchain.com/address/0x3Ff72741fd67D6AD0668d93B41a09248F4700560).