### PR TITLE
Update Berachain testnet

### DIFF
--- a/core/base/src/constants/nativeChainIds.ts
+++ b/core/base/src/constants/nativeChainIds.ts
@@ -108,7 +108,7 @@ const chainNetworkNativeChainIdEntries = [
       ["Blast",           168587773n], // Sepolia testnet
       ["Mantle",          5003n], // Sepolia testnet
       ["Scroll",          534351n],
-      ["Berachain",       80084n], // Testnet v2
+      ["Berachain",       80069n], // Testnet v3
       ["Seievm",          1328n],
       ["Snaxchain",       13001n],
       ["Unichain",        1301n],

--- a/core/base/src/constants/rpc.ts
+++ b/core/base/src/constants/rpc.ts
@@ -85,7 +85,7 @@ const rpcConfig = [[
     ["Karura",          "https://eth-rpc-karura-testnet.aca-staging.network"],
     ["Acala",           "https://eth-rpc-acala-testnet.aca-staging.network"],
     ["Blast",           "https://sepolia.blast.io"],
-    ["Berachain",       "https://artio.rpc.berachain.com"],
+    ["Berachain",       "https://bepolia.rpc.berachain.com/"],
     ["Seievm",          "https://evm-rpc-testnet.sei-apis.com/"],
     ["Linea",           "https://rpc.sepolia.linea.build"],
     ["Xlayer",          "https://testrpc.xlayer.tech/"],


### PR DESCRIPTION
Berachain has redeployed their testnet to Bepolia. Although this didn't change the contract addresses, it did change the EVM chain ID. This PR updates that.

- The core is available [here](https://bepolia.beratrail.io/address/0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd).
- The token bridge is available [here](https://bepolia.beratrail.io/address/0xa10f2eF61dE1f19f586ab8B6F2EbA89bACE63F7a).

Note that the explorer labels the core as a token bridge, but if you look at the "Read as Proxy" tab, you will see it is really the core.