### PR TITLE
Update Polygon testnet

### DIFF
--- a/core/base/src/constants/explorer.ts
+++ b/core/base/src/constants/explorer.ts
@@ -136,7 +136,7 @@ const explorerConfig = [[
     }], [
     "Polygon", {
       name: "PolygonScan",
-      baseUrl: "https://mumbai.polygonscan.com/",
+      baseUrl: "https://amoy.polygonscan.com/",
       endpoints: {
         tx: "tx/",
         account: "address/",

--- a/core/base/src/constants/nativeChainIds.ts
+++ b/core/base/src/constants/nativeChainIds.ts
@@ -94,7 +94,7 @@ const chainNetworkNativeChainIdEntries = [
       ["Neon",            245022940n],
       ["Oasis",           42261n],
       ["Optimism",        420n],
-      ["Polygon",         80001n], //mumbai
+      ["Polygon",         80002n], //amoy
       ["Sepolia",         11155111n],
       ["ArbitrumSepolia", 421614n],
       ["BaseSepolia",     84532n],

--- a/core/base/src/constants/rpc.ts
+++ b/core/base/src/constants/rpc.ts
@@ -53,7 +53,7 @@ const rpcConfig = [[
   ]], [
   "Testnet", [
     ["Ethereum",        "https://eth-sepolia.public.blastapi.io"],
-    ["Polygon",         "https://rpc-mumbai.polygon.technology"],
+    ["Polygon",         "https://rpc-amoy.polygon.technology"],
     ["Bsc",             "https://data-seed-prebsc-1-s3.binance.org:8545"],
     ["Avalanche",       "https://api.avax-test.network/ext/bc/C/rpc"],
     ["Fantom",          "https://rpc.testnet.fantom.network"],

--- a/tokenRegistry/src/scripts/importConnect.ts
+++ b/tokenRegistry/src/scripts/importConnect.ts
@@ -1,10 +1,12 @@
-import {
+import type {
   Platform,
   Chain,
   Network,
+  tokens
+} from "@wormhole-foundation/sdk-connect";
+import {
   chainToPlatform,
-  isChain,
-  tokens,
+  isChain
 } from "@wormhole-foundation/sdk-connect";
 import axios from "axios";
 import fs from "fs";
@@ -43,7 +45,7 @@ type TokenConfig = {
 
 const testnetChainMap: Record<string, Chain> = {
   goerli: "Ethereum",
-  mumbai: "Polygon",
+  amoy: "Polygon",
   alfajores: "Celo",
   fuji: "Avalanche",
   moonbasealpha: "Moonbeam",

--- a/tokenRegistry/src/tokens/TestnetTokens.json
+++ b/tokenRegistry/src/tokens/TestnetTokens.json
@@ -247,50 +247,6 @@
           "decimals": 18
         }
       }
-    },
-    "0x0FA8781a83E46826621b3BC094Ea2A0212e71B23": {
-      "name": "USDC (Mumbai)",
-      "symbol": "USDC",
-      "nativeChain": "Polygon",
-      "decimals": 6,
-      "foreignAssets": {
-        "Ethereum": {
-          "address": "0xB3658B4C6704356F155c369F4583aF68424128e9",
-          "decimals": 6
-        },
-        "Bsc": {
-          "address": "0x88B8b85ED6d39E613d2d1449e1c1B808d505D561",
-          "decimals": 6
-        },
-        "Avalanche": {
-          "address": "0xFB2C24197A92598C633Ed8eE60ee90b104d7B145",
-          "decimals": 6
-        },
-        "Fantom": {
-          "address": "0x450dC724a1793b0E2182d09Eb883ad76f7F4C0Aa",
-          "decimals": 6
-        },
-        "Celo": {
-          "address": "0x4364bb251a0F33914AAb2088ed435122694Ce2BD",
-          "decimals": 6
-        },
-        "Moonbeam": {
-          "address": "0x5366c7204A49D6CdD6A99e647aE695Cb0866FD5e",
-          "decimals": 6
-        },
-        "Sui": {
-          "address": "0xe1deb395283034cbfc81c5acb4c89d3223e5165b5384282c73963aa5262a4993::coin::COIN",
-          "decimals": 6
-        },
-        "Sei": {
-          "address": "sei1vccw9g60mphsaj9t96vru53mjje3vmxcl49lg8lfqdh0zgmq6zsqf03y9n",
-          "decimals": 6
-        },
-        "Solana": {
-          "address": "2ihQfgFiZnqEMrFuk4rUUoLvtEjAuza5TaysK4oc7rPK",
-          "decimals": 6
-        }
-      }
     }
   },
   "Bsc": {


### PR DESCRIPTION
Mumbai testnet is deprecated. This change updates Mumbai mentions to the Amoy testnet.
Also, the USDC testnet token (0x0FA8781a83E46826621b3BC094Ea2A0212e71B23) was removed, because it does not work anymore.