### PR TITLE
update bsc rpc on mainnet

### DIFF
--- a/core/base/src/constants/rpc.ts
+++ b/core/base/src/constants/rpc.ts
@@ -9,7 +9,7 @@ const rpcConfig = [[
     ["Ethereum",  "https://ethereum-rpc.publicnode.com"],
     ["Solana",    "https://api.mainnet-beta.solana.com"],
     ["Polygon",   "https://polygon-bor-rpc.publicnode.com"],
-    ["Bsc",       "https://bscrpc.com"],
+    ["Bsc",       "https://bsc-rpc.publicnode.com"],
     ["Avalanche", "https://avalanche-c-chain-rpc.publicnode.com"],
     ["Fantom",    "https://rpcapi.fantom.network"],
     ["Celo",      "https://celo-rpc.publicnode.com"],


### PR DESCRIPTION
old bsc RPC returned following error:

> server response 401 Unauthorized (request={  }, response={  }, error=null, info={ "requestUrl": "https://bscrpc.com", "responseBody": "{\"error\":\"message: API key disabled, json-rpc code: -32051, rest code: 403\"}", "responseStatus": "401 Unauthorized" }