### PR TITLE
Add expiration time to `Quote`

### DIFF
--- a/connect/src/protocols/cctp/cctpTransfer.ts
+++ b/connect/src/protocols/cctp/cctpTransfer.ts
@@ -1,4 +1,5 @@
 import type { Chain, Network } from "@wormhole-foundation/sdk-base";
+import { time } from "@wormhole-foundation/sdk-base";
 import { circle, encoding, finality, guardians, toChain } from "@wormhole-foundation/sdk-base";
 import type {
   Attestation,
@@ -622,6 +623,10 @@ export namespace CircleTransfer {
       destinationNativeGas = await dcb.nativeTokenAmount(_nativeGas);
     }
 
+    const expires = transfer.automatic ?
+      time.expiration(0, 10, 0) : // 10 minutes for automatic transfers
+      time.expiration(24, 0, 0);  // 24 hours for manual
+
     return {
       sourceToken: {
         token: srcToken,
@@ -631,6 +636,7 @@ export namespace CircleTransfer {
       relayFee: { token: srcToken, amount: fee },
       destinationNativeGas,
       eta,
+      expires,
     };
   }
 

--- a/connect/src/protocols/cctp/cctpTransfer.ts
+++ b/connect/src/protocols/cctp/cctpTransfer.ts
@@ -624,8 +624,8 @@ export namespace CircleTransfer {
     }
 
     const expires = transfer.automatic ?
-      time.expiration(0, 10, 0) : // 10 minutes for automatic transfers
-      time.expiration(24, 0, 0);  // 24 hours for manual
+      time.expiration(0, 5, 0) : // 5 minutes for automatic transfers
+      time.expiration(24, 0, 0); // 24 hours for manual
 
     return {
       sourceToken: {

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -4,6 +4,7 @@ import {
   encoding,
   finality,
   guardians,
+  time,
   toChain as toChainName,
 } from "@wormhole-foundation/sdk-base";
 import type {
@@ -753,6 +754,7 @@ export namespace TokenTransfer {
         destinationToken: { token: dstToken, amount: amount.units(dstAmountReceivable) },
         warnings: warnings.length > 0 ? warnings : undefined,
         eta,
+        expires: time.expiration(24, 0, 0), // manual transfer quote is good for 24 hours
       };
     }
 
@@ -842,6 +844,7 @@ export namespace TokenTransfer {
       destinationNativeGas,
       warnings: warnings.length > 0 ? warnings : undefined,
       eta,
+      expires: time.expiration(0, 10, 0), // automatic transfer quote is good for 10 minutes
     };
   }
 

--- a/connect/src/protocols/tokenBridge/tokenTransfer.ts
+++ b/connect/src/protocols/tokenBridge/tokenTransfer.ts
@@ -844,7 +844,7 @@ export namespace TokenTransfer {
       destinationNativeGas,
       warnings: warnings.length > 0 ? warnings : undefined,
       eta,
-      expires: time.expiration(0, 10, 0), // automatic transfer quote is good for 10 minutes
+      expires: time.expiration(0, 5, 0), // automatic transfer quote is good for 5 minutes
     };
   }
 

--- a/connect/src/routes/portico/automatic.ts
+++ b/connect/src/routes/portico/automatic.ts
@@ -1,4 +1,4 @@
-import { filters, finality } from "@wormhole-foundation/sdk-base";
+import { filters, finality, time } from "@wormhole-foundation/sdk-base";
 import type { StaticRouteMethods } from "../route.js";
 import { AutomaticRoute } from "../route.js";
 import type {
@@ -248,6 +248,7 @@ export class AutomaticPorticoRoute<N extends Network>
             amount: fee,
           },
           eta: finality.estimateFinalityTime(request.fromChain.chain),
+          expires: time.expiration(0, 10, 0),
         },
         params,
         details,

--- a/connect/src/routes/portico/automatic.ts
+++ b/connect/src/routes/portico/automatic.ts
@@ -248,7 +248,7 @@ export class AutomaticPorticoRoute<N extends Network>
             amount: fee,
           },
           eta: finality.estimateFinalityTime(request.fromChain.chain),
-          expires: time.expiration(0, 10, 0),
+          expires: time.expiration(0, 5, 0),
         },
         params,
         details,

--- a/connect/src/routes/request.ts
+++ b/connect/src/routes/request.ts
@@ -73,6 +73,7 @@ export class RouteTransferRequest<N extends Network> {
     }
 
     dq.eta = quote.eta;
+    dq.expires = quote.expires;
 
     if (details) {
       dq.details = details;

--- a/connect/src/routes/tbtc/tbtc.ts
+++ b/connect/src/routes/tbtc/tbtc.ts
@@ -5,6 +5,7 @@ import {
   finality,
   guardians,
   Network,
+  time,
 } from "@wormhole-foundation/sdk-base";
 import { ManualRoute, StaticRouteMethods } from "../route.js";
 import {
@@ -139,6 +140,7 @@ export class TBTCRoute<N extends Network>
         amount: params.normalizedParams.amount,
       },
       eta,
+      expires: time.expiration(24, 0, 0),
     };
   }
 

--- a/connect/src/routes/types.ts
+++ b/connect/src/routes/types.ts
@@ -78,6 +78,9 @@ export type Quote<
 
   // Estimated time to completion in milliseconds
   eta?: number;
+
+  // Timestamp when the quote expires
+  expires?: Date;
 };
 
 export type QuoteError = {

--- a/connect/src/types.ts
+++ b/connect/src/types.ts
@@ -211,4 +211,6 @@ export interface TransferQuote {
   warnings?: QuoteWarning[];
   // Estimated time to completion in milliseconds
   eta?: number;
+  // Timestamp when the quote expires
+  expires?: Date;
 }

--- a/core/base/__tests__/time.ts
+++ b/core/base/__tests__/time.ts
@@ -1,0 +1,27 @@
+import { time } from './../src/index.js';
+
+describe("Time Tests", function () {
+
+  const assertTimeDelta = (d1: Date, d2: Date, h: number, m: number, s: number) => {
+    const delta = d2.valueOf() - d1.valueOf();
+    const expectedDelta = ((h * 60 * 60) + (m * 60) + s) * 1000;
+
+    // Ensure the delta is within 1000 milliseconds of the expected value
+    // There will be a little variance here just due to CPU time
+    const deltaDelta = Math.abs(delta - expectedDelta);
+    expect(deltaDelta < 1000);
+  }
+
+  it("should generate a Date in the future", function () {
+    const d = new Date();
+    const fiveHours = time.expiration(5, 0, 0);
+    const fiveMinutes = time.expiration(0, 5, 0);
+    const fiveSeconds = time.expiration(0, 0, 5);
+    const tenHoursFiveMinutesThirtySeconds = time.expiration(10, 5, 30);
+
+    assertTimeDelta(d, fiveHours, 5, 0, 0);
+    assertTimeDelta(d, fiveMinutes, 0, 5, 0);
+    assertTimeDelta(d, fiveSeconds, 0, 0, 5);
+    assertTimeDelta(d, tenHoursFiveMinutesThirtySeconds, 10, 5, 30);
+  });
+});

--- a/core/base/src/utils/index.ts
+++ b/core/base/src/utils/index.ts
@@ -5,4 +5,5 @@ export * from "./misc.js";
 export * from "./layout.js";
 
 export * as amount from "./amount.js";
+export * as time from "./time.js";
 export * as encoding from "./encoding.js";

--- a/core/base/src/utils/time.ts
+++ b/core/base/src/utils/time.ts
@@ -1,6 +1,3 @@
 export const expiration = (hours: number = 0, minutes: number = 0, seconds: number = 0): Date => {
-  return (new Date(
-    new Date().valueOf() +
-    (((hours*60*60) + (minutes*60) + seconds) * 1000)
-  ));
+  return (new Date(Date.now() + (((hours*60*60) + (minutes*60) + seconds) * 1000)));
 }

--- a/core/base/src/utils/time.ts
+++ b/core/base/src/utils/time.ts
@@ -1,0 +1,6 @@
+export const expiration = (hours: number = 0, minutes: number = 0, seconds: number = 0): Date => {
+  return (new Date(
+    new Date().valueOf() +
+    (((hours*60*60) + (minutes*60) + seconds) * 1000)
+  ));
+}


### PR DESCRIPTION
- expose how long a quote is good for
- set to 5 minutes for relayed routes
- set to 24 hours for manual routes (which technically never expire)