### PR TITLE
ci: bump setup-node to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.x' 
       - run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"


### PR DESCRIPTION
Maintenance update: switch all jobs to setup-node@v4 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v4.0.0 release](https://github.com/actions/setup-node/releases/tag/v4.0.0).