### PR TITLE
Update L2WormholeGateway contract link in tBTC route README

### DIFF
--- a/connect/src/routes/tbtc/README.md
+++ b/connect/src/routes/tbtc/README.md
@@ -2,4 +2,4 @@ The TBTCRoute enables the transfer of both native and Wormhole-wrapped Ethereum 
 
 Arbitrum, Base, Optimism, Polygon, and Solana have a gateway contract. This contract mints native TBTC when it receives a payload3 transfer of Wormhole-wrapped TBTC from the token bridge. Conversely, it burns native TBTC, unlocks and bridges Wormhole-wrapped TBTC through the token bridge when bridging out. Wormhole-wrapped TBTC serves as the "highway" asset for bridging TBTC between chains. Transfers of TBTC to chains without a gateway contract are regular token bridge transfers.
 
-You can view the EVM L2WormholeGateway contract code [here](https://github.com/keep-network/tbtc-v2/blob/main/solidity/contracts/l2/L2WormholeGateway.sol). The Solana program is [here](https://github.com/keep-network/tbtc-v2/tree/main/cross-chain/solana).
+You can view the EVM L2WormholeGateway contract code [here](https://docs.threshold.network/app-development/tbtc-v2/tbtc-contracts-api/tbtc-v2-api/l2wormholegateway). The Solana program is [here](https://github.com/keep-network/tbtc-v2/tree/main/cross-chain/solana).


### PR DESCRIPTION
Replaced the outdated link to the L2WormholeGateway.sol source file with the current official documentation link in the tBTC route README. This ensures users have access to up-to-date information about the contract and its functionality.