### PR TITLE
core: fix token bridge transfer payload layout definition

### DIFF
--- a/core/definitions/src/protocols/tokenBridge/tokenBridgeLayout.ts
+++ b/core/definitions/src/protocols/tokenBridge/tokenBridgeLayout.ts
@@ -45,7 +45,7 @@ export const transferLayout = [
   payloadIdItem(1),
   ...transferCommonLayout,
   { name: "fee", ...amountItem },
-];
+] as const;
 
 export const transferWithPayloadLayout = <const P extends CustomizableBytes = undefined>(
   customPayload?: P,


### PR DESCRIPTION
While working on a project using the sdk I noticed some weird type inference when using the Token Bridge generated types:

![image](https://github.com/user-attachments/assets/e00973ca-62a8-4e68-add8-b86b8b21ed12)

See the `readonly [x: string]: bigint;` property of the type.

After applying this change the type worked as it previously did:

![image](https://github.com/user-attachments/assets/b5e75fc0-fc58-43e2-a33c-c83fb3a67c98)
