### PR TITLE
update plume finality

### DIFF
--- a/core/base/src/constants/finality.ts
+++ b/core/base/src/constants/finality.ts
@@ -65,7 +65,7 @@ const finalityThresholds = [
   ["Sonic",     1],
   ["Converge",  4096],
   ["Fogo",      32],
-  ["Plume",     64],
+  ["Plume",     4096], // inferred from testing
   ["Cosmoshub", 0],
   ["Evmos",     0],
   ["Kujira",    0],


### PR DESCRIPTION
increase finality from 64 to 4096

Plume finality is observed as requiring 3k-4k blocks. This sets the finality to 4096.