### PR TITLE
fix: correct typos in Circle Messenger error and documentation strings

### DIFF
--- a/core/definitions/src/protocols/governance/layout.ts
+++ b/core/definitions/src/protocols/governance/layout.ts
@@ -95,7 +95,7 @@ const wormchainActions = [
 // It has a variable length string that has no length prefix as its first item followed by a uint.
 // So deserialization has to reason backwards to determine the length.
 // see: https://github.com/wormhole-foundation/wormhole/blob/2eb5cca8e72c5379cd444ae3f25a012c1e04ad65/sdk/vaa/payloads.go#L396-L407
-// We have to do a bit of footwork here to accomodate this oddity.
+// We have to do a bit of footwork here to accommodate this oddity.
 const gatewayScheduleUpgradeItem = (() => {
   const stringBytesLayout = (size: number) =>
     ({ binary: "bytes", size, custom: stringConversion } as const satisfies Layout);

--- a/platforms/evm/protocols/cctp/src/circleBridge.ts
+++ b/platforms/evm/protocols/cctp/src/circleBridge.ts
@@ -67,7 +67,7 @@ export class EvmCircleBridge<N extends Network, C extends EvmChains>
     const msgTransmitterAddress = contracts.cctp?.messageTransmitter;
     if (!msgTransmitterAddress)
       throw new Error(
-        `Circle Messenge Transmitter contract for domain ${chain} not found`,
+        `Circle Messenger Transmitter contract for domain ${chain} not found`,
       );
 
     this.msgTransmitter = ethers_contracts.MessageTransmitter__factory.connect(

--- a/platforms/solana/protocols/cctp/src/anchor-idl/messageTransmitter.ts
+++ b/platforms/solana/protocols/cctp/src/anchor-idl/messageTransmitter.ts
@@ -742,7 +742,7 @@ export type MessageTransmitter = {
       name: 'usedNonces';
       docs: [
         'UsedNonces account holds an array of bits that indicate which nonces were already used',
-        "so they can't be resused to receive new messages. Array starts with the first_nonce and",
+        "so they can't be reused to receive new messages. Array starts with the first_nonce and",
         'holds flags for UsedNonces::MAX_NONCES. Nonces are recorded separately for each remote_domain.',
       ];
       type: {
@@ -2110,7 +2110,7 @@ export const MessageTransmitterIdl: MessageTransmitter = {
       name: 'usedNonces',
       docs: [
         'UsedNonces account holds an array of bits that indicate which nonces were already used',
-        "so they can't be resused to receive new messages. Array starts with the first_nonce and",
+        "so they can't be reused to receive new messages. Array starts with the first_nonce and",
         'holds flags for UsedNonces::MAX_NONCES. Nonces are recorded separately for each remote_domain.',
       ],
       type: {

--- a/platforms/solana/protocols/cctp/src/circleBridge.ts
+++ b/platforms/solana/protocols/cctp/src/circleBridge.ts
@@ -57,7 +57,7 @@ export class SolanaCircleBridge<N extends Network, C extends SolanaChains>
     const msgTransmitterAddress = contracts.cctp?.messageTransmitter;
     if (!msgTransmitterAddress)
       throw new Error(
-        `Circle Messenge Transmitter contract for domain ${chain} not found`,
+        `Circle Messenger Transmitter contract for domain ${chain} not found`,
       );
 
     this.messageTransmitter = createReadOnlyMessageTransmitterProgramInterface(


### PR DESCRIPTION
Fixed typo Messenge → Messenger in error message string in both EVM and Solana circleBridge.ts.

Fixed typo resused → reused in documentation comments of messageTransmitter.ts (Anchor IDL).
These changes improve clarity and consistency in error reporting and documentation.