### PR TITLE
Handle special address that represents ETH

### DIFF
--- a/platforms/evm/src/indexer.ts
+++ b/platforms/evm/src/indexer.ts
@@ -52,7 +52,13 @@ export class GoldRushClient {
 
     const bals: Balances = {};
     for (let item of data.items) {
-      bals[item.contract_address] = BigInt(item.balance);
+      let addr = item.contract_address;
+
+      if (item.contract_address.toLowerCase() === '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') {
+        addr = 'native';
+      }
+
+      bals[addr] = BigInt(item.balance);
     }
 
     return bals;


### PR DESCRIPTION
Covalent started returning the address `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` to represent the wallet's native gas balance. The code downstream was treating this as an ERC-20 and failing to load decimals, since it's not a valid token.