### PR TITLE
feat: add circle geoblocking

### DIFF
--- a/connect/src/routes/cctp/automatic.ts
+++ b/connect/src/routes/cctp/automatic.ts
@@ -23,6 +23,7 @@ import type {
   ValidationResult,
 } from "../types.js";
 import type { RouteTransferRequest } from "../request.js";
+import { checkCircleGeoblock } from "../../circle-api.js";
 
 export namespace AutomaticCCTPRoute {
   export type Options = {
@@ -123,6 +124,12 @@ export class AutomaticCCTPRoute<N extends Network>
 
   async quote(request: RouteTransferRequest<N>, params: Vp): Promise<QR> {
     try {
+      const geoBlockError = await checkCircleGeoblock();
+
+      if (geoBlockError) {
+        return geoBlockError;
+      }
+
       return request.displayQuote(
         await CircleTransfer.quoteTransfer(request.fromChain, request.toChain, {
           automatic: true,

--- a/connect/src/routes/cctp/manual.ts
+++ b/connect/src/routes/cctp/manual.ts
@@ -24,6 +24,7 @@ import type {
   ValidationResult,
 } from "../types.js";
 import type { RouteTransferRequest } from "../request.js";
+import { checkCircleGeoblock } from "../../circle-api.js";
 
 export namespace CCTPRoute {
   export type Options = {
@@ -109,6 +110,12 @@ export class CCTPRoute<N extends Network>
 
   async quote(request: RouteTransferRequest<N>, params: Vp): Promise<QR> {
     try {
+      const geoBlockError = await checkCircleGeoblock();
+
+      if (geoBlockError) {
+        return geoBlockError;
+      }
+
       return request.displayQuote(
         await CircleTransfer.quoteTransfer(request.fromChain, request.toChain, {
           automatic: false,


### PR DESCRIPTION
Pings Circle's geoblock API. If it succeeds, they are good. If it fails with specific statuses, they are geoblocked. If it fails because of a network issue, it continues. We could change this last behavior, but I could see it adding friction or causing confusion.

We will simply render this `Error` in connect, for an ultimate view like this:

<img width="561" height="543" alt="Screenshot 2025-07-29 at 12 54 59 PM" src="https://github.com/user-attachments/assets/1ede932d-1e99-4b2f-80b9-85614ea1cc4b" />
