### PR TITLE
fix: Use iris-api.circle.com for circle pings

### DIFF
--- a/connect/src/circle-api.ts
+++ b/connect/src/circle-api.ts
@@ -59,7 +59,7 @@ export async function checkCircleGeoblock(): Promise<{
   error: Error;
 } | null> {
   try {
-    const url = "https://api.circle.com/ping";
+    const url = "https://iris-api.circle.com/ping";
 
     await axios.get<{
       status?: string;


### PR DESCRIPTION
Since it is allowlisted in portal's CSP and also returns a proper ACAO header.