### PR TITLE
fix: correct typos in mapping utils and Solana platform docs

### DIFF
--- a/core/base/src/utils/mapping.ts
+++ b/core/base/src/utils/mapping.ts
@@ -182,7 +182,7 @@ type KeyColumnToKeyRowIndexes<KC extends RoTuple<MappableKey>> =
   ? ToMapEntries<FIP>
   : never;
 
-//Takes the first of the reamining key columns and splits it into chunks that share the same key
+//Takes the first of the remaining key columns and splits it into chunks that share the same key
 //  value. Then invokes itself for each sub-chunk passing along only those value rows that belong
 //  to that chunk.
 //In our example for the default shape, it starts with the network column and splits it into

--- a/sdk/src/platforms/solana.ts
+++ b/sdk/src/platforms/solana.ts
@@ -1,7 +1,7 @@
 import { applyChainsConfigConfigOverrides } from "@wormhole-foundation/sdk-connect";
 import * as _solana from "@wormhole-foundation/sdk-solana";
 import type { PlatformDefinition } from "../index.js";
-/** Platform and protocol definitons for Solana */
+/** Platform and protocol definitions for Solana */
 const solana: PlatformDefinition<typeof _solana._platform> = {
   Address: _solana.SolanaAddress,
   Platform: _solana.SolanaPlatform,


### PR DESCRIPTION
core/base/src/utils/mapping.ts: fixed typo (reamining → remaining) in comment.

sdk/src/platforms/solana.ts: fixed typo in docstring (definitons → definitions).