### PR TITLE
allow Quote to carry a provider

### DIFF
--- a/connect/src/routes/types.ts
+++ b/connect/src/routes/types.ts
@@ -81,6 +81,10 @@ export type Quote<
 
   // Timestamp when the quote expires
   expires?: Date;
+
+  // Optional provider string to override RouteMeta.provider
+  // Can be useful for an aggregator route which quotes from multiple providers
+  provider?: string;
 };
 
 export type QuoteError = {


### PR DESCRIPTION
A Route representing an aggregator service might be quoting from multiple different underlying providers, but right now there is no interface for expressing that. This lets a `Quote` carry an optional `provider` string for this purpose.