### PR TITLE
fix: prevent function from blocking quote fetching

### DIFF
--- a/connect/src/routes/token.ts
+++ b/connect/src/routes/token.ts
@@ -40,7 +40,16 @@ export async function getTokenDetails<N extends Network>(
     : undefined;
 
   const symbol = details ? details.symbol : undefined;
-  const wrapped = isNative(token.address) ? await chain.getNativeWrappedTokenId() : undefined;
+  let wrapped: TokenId | undefined = undefined;
+
+  if (isNative(token.address)) {
+    try {
+      wrapped = await chain.getNativeWrappedTokenId();
+    } catch {
+      // noop
+    }
+  }
+
   decimals = decimals ?? (await chain.getDecimals(token.address));
 
   return {


### PR DESCRIPTION
Seeing this error when trying to swap using the HYPE token: `Wormhole Token Bridge contract for domain HyperEVM not found`

The error comes in [this function](https://github.com/wormhole-foundation/wormhole-connect/blob/development/src/routes/sdkv2/route.ts#L224).

Since this function blocks fetching quotes from other routes, Mayan route code never gets called