### PR TITLE
feat: add Ink explorer configuration

### DIFF
--- a/core/base/src/constants/explorer.ts
+++ b/core/base/src/constants/explorer.ts
@@ -108,6 +108,14 @@ const explorerConfig = [[
         account: "address/",
       },
     }], [
+    "Ink", {
+      name: "Ink Explorer",
+      baseUrl: "https://explorer.inkonchain.com/",
+      endpoints: {
+        tx: "tx/",
+        account: "address/"
+      },
+    }], [
     "Mezo", {
       name: "Mezo Explorer",
       baseUrl: "https://explorer.mezo.org/",
@@ -267,6 +275,14 @@ const explorerConfig = [[
       endpoints: {
         tx: "transaction/",
         account: "address/",
+      },
+    }], [
+    "Ink", {
+      name: "Ink Sepolia Explorer",
+      baseUrl: "https://explorer-sepolia.inkonchain.com/",
+      endpoints: {
+        tx: "tx/",
+        account: "address/"
       },
     }], [
     "Mezo", {


### PR DESCRIPTION
## Summary
- Adds mainnet Ink explorer configuration at https://explorer.inkonchain.com/
- Adds testnet (Sepolia) Ink explorer configuration at https://explorer-sepolia.inkonchain.com/

This completes the Ink chain integration in the SDK by adding the missing explorer endpoints.

## Test Plan
- [x] SDK builds successfully
- [x] TypeScript compilation passes