### PR TITLE
Hypercore

### DIFF
--- a/core/base/src/constants/circle.ts
+++ b/core/base/src/constants/circle.ts
@@ -29,7 +29,7 @@ const usdcContracts = [[
     ["HyperEVM",  "0xb88339CB7199b77E23DB6E890353E22632Ba630f"],
     ["Plume",     "0x222365EF19F7947e5484218551B56bb3965Aa7aF"],
     ["Ink",       "0x2D270e6886d130D724215A266106e6832161EAEd"],
-    // ["HyperCore", "not-implemented"],
+    ["HyperCore", "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"], // not an actual EVM platform; using Arbitrum address
   ]], [
   "Testnet", [
     ["Sepolia",         "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"],

--- a/core/base/src/constants/decimals.ts
+++ b/core/base/src/constants/decimals.ts
@@ -12,7 +12,6 @@ const nativeDecimalEntries = [
   ["Algorand",     6],
   ["Btc",          8],
   ["Near",        12],
-  ["HyperLiquid",  8],
 ] as const satisfies MapLevel<Platform, number>;
 
 /** Number of decimals for the native token on a given platform */

--- a/core/base/src/constants/platforms.ts
+++ b/core/base/src/constants/platforms.ts
@@ -40,6 +40,7 @@ const platformAndChainsEntries = [[
     "XRPLEVM",
     "Plasma",
     "CreditCoin",
+    "HyperCore", // not an actual EVM platform; treating as EVM
   ]], [
   "Solana", [
     "Solana",
@@ -76,9 +77,6 @@ const platformAndChainsEntries = [[
   ]], [
     "Near", [
       "Near"
-  ]], [
-    "HyperLiquid", [
-      "HyperCore"
   ]],
 ] as const satisfies MapLevel<string, RoArray<Chain>>;
 
@@ -104,7 +102,6 @@ const platformAddressFormatEntries = [
   ["Sui",       "hex"],
   ["Aptos",     "hex"],
   ["Near",      "sha256"],
-  ["HyperLiquid", "hex"],
 ] as const;
 
 export const platformToAddressFormat = constMap(platformAddressFormatEntries);


### PR DESCRIPTION
Adds hypercore to supported USDC chain. Uses Arb address and assumes EVM chain, as it's not really any specific chain and creating a platform for this alone would be overkill.