### PR TITLE
chore: update HyperCore chain ID

### DIFF
--- a/core/base/src/constants/chains.ts
+++ b/core/base/src/constants/chains.ts
@@ -66,8 +66,8 @@ const chainIdAndChainEntries = [
   [10005, "OptimismSepolia"],
   [10006, "Holesky"        ],
   [10007, "PolygonSepolia" ],
-  // placeholder; guardians are not connected to HyperCore
-  [20000, "HyperCore"      ],
+  // guardians are not connected to HyperCore; this is an arbitrary number chosen by Mayan
+  [65000, "HyperCore"      ],
 ] as const satisfies MapLevel<number, string>;
 
 export const [chainIds, chains] = zip(chainIdAndChainEntries);

--- a/core/base/src/constants/nativeChainIds.ts
+++ b/core/base/src/constants/nativeChainIds.ts
@@ -100,7 +100,7 @@ const chainNetworkNativeChainIdEntries = [
       ["Worldchain",      4801n],
       ["Ink",             763373n],
       ["HyperEVM",        998n],
-      ["HyperCore",       20000n],
+      ["HyperCore",       65000n],
       ["Xlayer",          195n],
       ["Linea",           59141n], // Sepolia
       ["Monad",           10143n],


### PR DESCRIPTION
Mayan uses `65000` for the HyperCore chain ID. It is arbitrary, since this is not a real chain.