### PR TITLE
chore: change HyperCore ID

### DIFF
--- a/core/base/src/constants/nativeChainIds.ts
+++ b/core/base/src/constants/nativeChainIds.ts
@@ -50,7 +50,7 @@ const chainNetworkNativeChainIdEntries = [
       ["Ink",       57073n],
       ["Sonic",     146n],
       ["HyperEVM",  999n],
-      ["HyperCore", 20000n],
+      ["HyperCore", 65000n],
       ["Mezo",      31612n],
       ["Plume",     98866n],
       ["XRPLEVM",   1440000n],


### PR DESCRIPTION
Uses Mayan's arbitrary `65000` now instead of our arbitrary `20000`