### PR TITLE
fix: reduce BSC blocktime to 750mS

### DIFF
--- a/core/base/src/constants/finality.ts
+++ b/core/base/src/constants/finality.ts
@@ -100,7 +100,7 @@ const blockTimeMilliseconds = [
   ["Avalanche",         2_000],
   ["Base",              2_000],
   ["BaseSepolia",       2_000],
-  ["Bsc",               3_000],
+  ["Bsc",               750],
   ["Celo",              5_000],
   ["Cosmoshub",         5_000],
   ["Ethereum",         15_000],


### PR DESCRIPTION
Fast finality is in ~2.5 blocks.  But if fast finality fails, then probabilistic finality is in 15 blocks.  So, we can change the block time in the code to reflect the reduced block time due to Maxwell hardfork. But probably shouldn't change the finality threshold.