### PR TITLE
adjust scroll & polygon finality

### DIFF
--- a/core/base/src/constants/finality.ts
+++ b/core/base/src/constants/finality.ts
@@ -33,11 +33,10 @@ const finalityThresholds = [
   ["Base",      512],
   ["Arbitrum", 4096], // TODO: validate, this is inferred from vaa metrics timing
   ["Xlayer",    300],
-  ["Scroll",    300],
+  ["Scroll",    999], // ~50min finality
   ["Mantle",    512],
   ["Worldchain",512],
-  // Check-pointed after 32 blocks
-  ["Polygon",  32],
+  ["Polygon",  2],  // ~5s finality
   // Single block finality
   ["Fantom",    1],
   ["Celo",      1],
@@ -81,7 +80,7 @@ const finalityThresholds = [
   ["ArbitrumSepolia", 4096],
   ["BaseSepolia", 512],
   ["OptimismSepolia", 512],
-  ["PolygonSepolia", 32],
+  ["PolygonSepolia", 2],
 ] as const satisfies MapLevel<Chain, number>;
 
 /**


### PR DESCRIPTION
update finality times based on respective documentation for Polygon and Scroll.
Polygon: 
"NOTE: With the upgrade to Heimdall v2, deterministic finality on PoS is now achieved in between 2-5 seconds thanks to the 1-2 seconds block time in Heimdall, meaning miletones are voted on and finalized much faster."
https://docs.polygon.technology/pos/concepts/finality/finality/?h=finality

Scroll:
"Finality depends on the parameterization of how often your chain wants to finalize to Ethereum. Roughly, a batch is created every minute (containing ~20 blocks or 200 txs), and takes about 50 minutes to finalize on L1."
https://docs.scroll.io/en/sdk/sdk-faq/



