### PR TITLE
feat: SeiEVM Testnet support via relayer and coreBridge addresses

### DIFF
--- a/core/base/src/constants/contracts/core.ts
+++ b/core/base/src/constants/contracts/core.ts
@@ -78,7 +78,7 @@ export const coreBridgeContracts = [[
     ["PolygonSepolia",  "0x6b9C8671cdDC8dEab9c719bB87cBd3e782bA6a35"],
     ["Scroll",          "0x055F47F1250012C6B20c436570a76e52c17Af2D5"],
     ["Berachain",       "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"],
-    ["Seievm",          "0x23908A62110e21C04F3A4e011d24F901F911744A"],
+    ["Seievm",          "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"],
     ["Unichain",        "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"],
     ["Worldchain",      "0xe5E02cD12B6FcA153b0d7fF4bF55730AE7B3C93A"],
     ["Ink",             "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"],


### PR DESCRIPTION
**We also need VERIFICATION** of the new address for `TokenBridgeRelayer` :https://testnet.seiscan.io/address/0x595712ba7e4882af338d60ae37058082a5d0331a#code
(specified in https://wormholelabs.notion.site/Public-Executor-Addresses-1f93029e88cb80df940eeb8867a01081)

Since you've added the SeiEVM Testnet configuration to the Wormhole SDK, **no changes are needed in this NTT repo https://github.com/wormhole-foundation/native-token-transfers**. The `overrides.json` can be deleted.

No changes needed in the NTT `native-token-transfer` repo. The executor address for SeiEVM Testnet is already present in `evm/ts/src/nttWithExecutor.ts` (line 59):

```typescript
Seievm: "0x3F2D6441C7a59Dfe80f8e14142F9E28F6D440445",
```

Once your Wormhole SDK PR is merged and the SDK version is updated, SeiEVM Testnet will work out of the box - same as Mainnet.