### PR TITLE
fix: megaETH TBR gas bump

### DIFF
--- a/platforms/evm/protocols/tokenBridge/src/executorTokenBridge.ts
+++ b/platforms/evm/protocols/tokenBridge/src/executorTokenBridge.ts
@@ -270,6 +270,7 @@ export class EvmExecutorTokenBridge<N extends Network, C extends EvmChains>
     switch (receivedToken.chain) {
       case 'Arbitrum':
       case 'Bsc':
+      case 'MegaETH':
       case 'Monad':
       case 'Moonbeam':
         gasLimit = 1_000_000n;


### PR DESCRIPTION
Tested the route [here](https://wormholelabs-xyz.github.io/executor-explorer/#/tx/2UVnA7ysoDfGxwWtir1Xm5UD3URfHaQqrmoxp2uHhXBhq2SiESc6Nr9ewdp32LjmmsY5Sf6V69yDGimWAzrdSKgd?endpoint=https%3A%2F%2Fexecutor.labsapis.com&env=Mainnet), it used a bit more gas than the default so adding headroom akin to other chains.