### PR TITLE
Remove Linea wtt (mainnet)

### DIFF
--- a/core/base/src/constants/contracts/tokenBridge.ts
+++ b/core/base/src/constants/contracts/tokenBridge.ts
@@ -33,7 +33,6 @@ export const tokenBridgeContracts = [[
     ["Worldchain",    "0xc309275443519adca74c9136b02A38eF96E3a1f6"],
     ["Ink",           "0x3Ff72741fd67D6AD0668d93B41a09248F4700560"],
     ["XRPLEVM",       "0x47F5195163270345fb4d7B9319Eda8C64C75E278"],
-    ["Linea",         "0x167E0752de62cb76EFc0Fbb165Bd342c6e2Bb251"],
     ["Monad",         "0x0B2719cdA2F10595369e6673ceA3Ee2EDFa13BA7"],
     ["Fogo",          "wormQuCVWSSmPdjVmEzAWxAXViVyTSWnLyhff5hVYGS"],
     // ["Moca",                "not yet in mainnet"]


### PR DESCRIPTION
Remove the WTT instance from Linea mainnet, as it's never been cross registered or used in production due to Linea's finality time and the inability to set a custom finality for WTT.