### PR TITLE
feat: add httpHeaders support to ChainConfig for custom RPC headers

### DIFF
--- a/core/definitions/src/types.ts
+++ b/core/definitions/src/types.ts
@@ -173,6 +173,8 @@ export type ChainConfig<N extends Network, C extends Chain> = {
    * Rpc address for this chain
    */
   rpc: string;
+  /** Custom HTTP headers to include with RPC requests (e.g. { Origin: "https://myapp.com" }) */
+  httpHeaders?: Record<string, string>;
   tokenMap?: ChainTokens;
   wrappedNative?: Token;
   explorer?: explorer.ExplorerSettings;

--- a/platforms/aptos/src/platform.ts
+++ b/platforms/aptos/src/platform.ts
@@ -40,8 +40,15 @@ export class AptosPlatform<N extends Network>
 
   getRpc<C extends AptosChains>(chain: C): Aptos {
     if (chain in this.config) {
+      const chainConfig = this.config[chain]!;
       const network = this.network === "Mainnet" ? AptosNetwork.MAINNET : AptosNetwork.TESTNET;
-      const config = new AptosConfig({ fullnode: this.config[chain]!.rpc, network });
+      const config = new AptosConfig({
+        fullnode: chainConfig.rpc,
+        network,
+        ...(chainConfig.httpHeaders && {
+          clientConfig: { HEADERS: chainConfig.httpHeaders },
+        }),
+      });
       return new Aptos(config);
     }
     throw new Error("No configuration available for chain: " + chain);

--- a/platforms/evm/src/platform.ts
+++ b/platforms/evm/src/platform.ts
@@ -22,7 +22,7 @@ import {
 } from '@wormhole-foundation/sdk-connect';
 
 import type { Provider } from 'ethers';
-import { JsonRpcProvider } from 'ethers';
+import { FetchRequest, JsonRpcProvider } from 'ethers';
 import * as ethers_contracts from './ethers-contracts/index.js';
 
 import { EvmAddress, EvmZeroAddress } from './address.js';
@@ -55,8 +55,15 @@ export class EvmPlatform<N extends Network>
     }
 
     if (chain in this.config && this.config[chain]!.rpc) {
+      const chainConfig = this.config[chain]!;
+      let connection: string | FetchRequest = chainConfig.rpc;
+      if (chainConfig.httpHeaders) {
+        connection = new FetchRequest(chainConfig.rpc);
+        for (const [k, v] of Object.entries(chainConfig.httpHeaders))
+          connection.setHeader(k, v);
+      }
       const provider = new JsonRpcProvider(
-        this.config[chain]!.rpc,
+        connection,
         nativeChainIds.networkChainToNativeChainId.get(this.network, chain),
         {
           staticNetwork: true,

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -61,8 +61,16 @@ export class SolanaPlatform<N extends Network>
       disableRetryOnRateLimit: true,
     },
   ): Connection {
-    if (chain in this.config)
-      return new Connection(this.config[chain]!.rpc, config);
+    if (chain in this.config) {
+      const chainConfig = this.config[chain]!;
+      if (chainConfig.httpHeaders) {
+        config = {
+          ...config,
+          httpHeaders: { ...chainConfig.httpHeaders, ...config.httpHeaders },
+        };
+      }
+      return new Connection(chainConfig.rpc, config);
+    }
     throw new Error('No configuration available for chain: ' + chain);
   }
 

--- a/platforms/sui/src/platform.ts
+++ b/platforms/sui/src/platform.ts
@@ -18,7 +18,7 @@ import {
   networkPlatformConfigs,
 } from "@wormhole-foundation/sdk-connect";
 
-import { PaginatedCoins, SuiClient } from "@mysten/sui/client";
+import { PaginatedCoins, SuiClient, SuiHTTPTransport } from "@mysten/sui/client";
 import { SuiAddress } from "./address.js";
 import { SuiChain } from "./chain.js";
 import { SUI_COIN } from "./constants.js";
@@ -41,7 +41,18 @@ export class SuiPlatform<N extends Network>
   }
 
   getRpc<C extends SuiChains>(chain: C): SuiClient {
-    if (chain in this.config) return new SuiClient({ url: this.config[chain]!.rpc });
+    if (chain in this.config) {
+      const chainConfig = this.config[chain]!;
+      if (chainConfig.httpHeaders) {
+        return new SuiClient({
+          transport: new SuiHTTPTransport({
+            url: chainConfig.rpc,
+            rpc: { headers: chainConfig.httpHeaders },
+          }),
+        });
+      }
+      return new SuiClient({ url: chainConfig.rpc });
+    }
     throw new Error("No configuration available for chain: " + chain);
   }
 

--- a/platforms/xrpl/src/platform.ts
+++ b/platforms/xrpl/src/platform.ts
@@ -48,8 +48,8 @@ export class XrplPlatform<N extends Network>
   }
 
   override getRpc<C extends XrplChains>(chain: C): Client {
-    const rpcUrl = this.config[chain]!.rpc;
-    return new Client(rpcUrl);
+    const chainConfig = this.config[chain]!;
+    return new Client(chainConfig.rpc, chainConfig.httpHeaders ? { headers: chainConfig.httpHeaders } : undefined);
   }
 
   override getChain<C extends XrplChains>(


### PR DESCRIPTION
Allow SDK users to set custom HTTP headers (e.g. Origin) on RPC requests by adding an optional httpHeaders field to ChainConfig. Wired through getRpc() for EVM, Solana, Sui, Aptos, and XRPL platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-chain custom HTTP headers configuration now available. Users can configure optional headers that will be automatically included with RPC requests for each blockchain network. This enhancement is supported across all platform implementations and provides greater flexibility for request customization and authentication management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->