### PR TITLE
fix: missing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11917,6 +11917,7 @@
         "@wormhole-foundation/sdk-connect": "1.20.0",
         "@wormhole-foundation/sdk-evm": "1.20.0",
         "@wormhole-foundation/sdk-evm-core": "1.20.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.20.0",
         "ethers": "^6.5.1"
       },
       "engines": {

--- a/platforms/evm/protocols/cctp/package.json
+++ b/platforms/evm/protocols/cctp/package.json
@@ -56,6 +56,7 @@
     "@wormhole-foundation/sdk-connect": "1.20.0",
     "@wormhole-foundation/sdk-evm": "1.20.0",
     "@wormhole-foundation/sdk-evm-core": "1.20.0",
+    "@wormhole-foundation/sdk-evm-tokenbridge": "1.20.0",
     "ethers": "^6.5.1"
   },
   "type": "module",


### PR DESCRIPTION
In our pnpm project, I was running into issues like `Failed to load required packages Error: Protocol Evm for protocol WormholeCore has already registered`.

`automaticCircleBridge.ts` imports `@wormhole-foundation/sdk-evm-tokenbridge` (side-effect import for protocol
  registration) but the `package.json` never declared it as a dependency. 

In pnpm strict mode, this causes the import to resolve from a different context, loading a duplicate copy of sdk-evm-core which tries to re-register the Evm/WormholeCore protocol on a shared singleton.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new runtime dependency for EVM token bridge support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->