### PR TITLE
feat: support executor callback overrides on WormholeConfig

### DIFF
--- a/connect/src/config.ts
+++ b/connect/src/config.ts
@@ -1,6 +1,10 @@
 import type { Chain, Network, Platform } from "@wormhole-foundation/sdk-base";
 import { circle, executor } from "@wormhole-foundation/sdk-base";
-import type { ChainConfig, ChainsConfig } from "@wormhole-foundation/sdk-definitions";
+import type {
+  CapabilitiesResponse,
+  ChainConfig,
+  ChainsConfig,
+} from "@wormhole-foundation/sdk-definitions";
 import { buildConfig } from "@wormhole-foundation/sdk-definitions";
 
 export const DEFAULT_TASK_TIMEOUT = 60 * 1000; // 1 minute in milliseconds
@@ -10,6 +14,10 @@ export type WormholeConfig<N extends Network = Network, P extends Platform = Pla
   circleAPI: string;
   executorAPI: string;
   chains: ChainsConfig<N, P>;
+  executor?: {
+    /** Override the default capabilities fetcher (e.g. to cache or use a custom endpoint). */
+    getCapabilities?: (network: Network) => Promise<CapabilitiesResponse>;
+  };
 };
 
 export const CONFIG = {
@@ -47,6 +55,8 @@ export function networkPlatformConfigs<N extends Network, P extends Platform>(
 type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? RecursivePartial<U>[]
+    : T[P] extends (...args: any[]) => any
+    ? T[P]
     : T[P] extends object | undefined
     ? RecursivePartial<T[P]>
     : T[P];

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -452,6 +452,9 @@ export class Wormhole<N extends Network> {
   }
 
   async getExecutorCapabilities(): Promise<CapabilitiesResponse> {
+    if (this.config.executor?.getCapabilities) {
+      return await this.config.executor.getCapabilities(this._network);
+    }
     return await fetchCapabilities(this.config.executorAPI);
   }
 


### PR DESCRIPTION
Allow users to pass a getCapabilities callback when constructing the Wormhole SDK object so every route can use it without per-route config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional custom executor capabilities fetcher so users can supply their own async capability retrieval.
* **Behavior Changes**
  * Configuration partials now preserve function-typed properties (function types remain intact in overrides), improving type accuracy and developer ergonomics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->