### PR TITLE
feat: support custom URL for indexer clients

### DIFF
--- a/connect/src/indexers/AlchemyClient.ts
+++ b/connect/src/indexers/AlchemyClient.ts
@@ -35,10 +35,12 @@ const RPC_ID_TOKEN_BALANCES = 1;
 const RPC_ID_NATIVE_BALANCE = 2;
 
 class AlchemyClient {
-  private key: string;
+  private key?: string;
+  private customUrl?: string;
 
-  constructor(key: string) {
-    this.key = key;
+  constructor(options: { key?: string; url?: string }) {
+    this.key = options.key;
+    this.customUrl = options.url;
   }
 
   supportsChain(network: Network, chain: Chain) {
@@ -51,7 +53,9 @@ class AlchemyClient {
     requests: Array<{ method: string; params: any[]; id: number }>,
     signal?: AbortSignal,
   ): Promise<Array<{ id: number; result: any }>> {
-    const baseUrl = `https://${endpoint}.g.alchemy.com/v2/${this.key}`;
+    const baseUrl = this.customUrl
+      ? `${this.customUrl}/${endpoint}`
+      : `https://${endpoint}.g.alchemy.com/v2/${this.key}`;
 
     const response = await fetch(baseUrl, {
       method: "POST",

--- a/connect/src/indexers/AlchemyClient.ts
+++ b/connect/src/indexers/AlchemyClient.ts
@@ -39,6 +39,9 @@ class AlchemyClient {
   private customUrl?: string;
 
   constructor(options: { key?: string; url?: string }) {
+    if (!options.key && !options.url) {
+      throw new Error("AlchemyClient requires either an API key or a custom URL");
+    }
     this.key = options.key;
     this.customUrl = options.url;
   }

--- a/connect/src/indexers/GoldRushClient.ts
+++ b/connect/src/indexers/GoldRushClient.ts
@@ -56,6 +56,9 @@ class GoldRushClient {
   private customUrl?: string;
 
   constructor(options: { key?: string; url?: string }) {
+    if (!options.key && !options.url) {
+      throw new Error("GoldRushClient requires either an API key or a custom URL");
+    }
     this.key = options.key;
     this.customUrl = options.url;
   }

--- a/connect/src/indexers/GoldRushClient.ts
+++ b/connect/src/indexers/GoldRushClient.ts
@@ -52,10 +52,12 @@ const GOLD_RUSH_CHAINS: Record<Network, Partial<Record<Chain, string>>> = {
 };
 
 class GoldRushClient {
-  private key: string;
+  private key?: string;
+  private customUrl?: string;
 
-  constructor(key: string) {
-    this.key = key;
+  constructor(options: { key?: string; url?: string }) {
+    this.key = options.key;
+    this.customUrl = options.url;
   }
 
   supportsChain(network: Network, chain: Chain) {
@@ -75,10 +77,11 @@ class GoldRushClient {
       throw new Error("Chain not supported by GoldRush indexer");
     }
 
-    const response = await fetch(
-      `https://api.covalenthq.com/v1/${endpoint}/address/${walletAddr}/balances_v2/?key=${this.key}`,
-      { signal },
-    );
+    const fetchUrl = this.customUrl
+      ? `${this.customUrl}/v1/${endpoint}/address/${walletAddr}/balances_v2/`
+      : `https://api.covalenthq.com/v1/${endpoint}/address/${walletAddr}/balances_v2/?key=${this.key}`;
+
+    const response = await fetch(fetchUrl, { signal });
 
     if (!response.ok) {
       throw new Error(`GoldRush API request failed with status ${response.status}`);

--- a/connect/src/indexers/balances.ts
+++ b/connect/src/indexers/balances.ts
@@ -62,13 +62,19 @@ export async function getWalletBalances(
   const clientConfigs: Array<IndexerClientConfig> = [
     {
       ...commonConfig,
-      client: goldRush?.apiKey ? new GoldRushClient(goldRush.apiKey) : undefined,
+      client:
+        goldRush?.apiKey || goldRush?.url
+          ? new GoldRushClient({ key: goldRush.apiKey, url: goldRush.url })
+          : undefined,
       name: "Gold Rush",
       timeoutMs: goldRush?.timeoutMs,
     },
     {
       ...commonConfig,
-      client: alchemy?.apiKey ? new AlchemyClient(alchemy.apiKey) : undefined,
+      client:
+        alchemy?.apiKey || alchemy?.url
+          ? new AlchemyClient({ key: alchemy.apiKey, url: alchemy.url })
+          : undefined,
       name: "Alchemy",
       timeoutMs: alchemy?.timeoutMs,
     },

--- a/connect/src/indexers/types.ts
+++ b/connect/src/indexers/types.ts
@@ -4,11 +4,19 @@ import type GoldRushClient from "./GoldRushClient.js";
 
 export interface IndexerConfig {
   goldRush?: {
-    apiKey: string;
+    /** API key for direct GoldRush/Covalent access. Not needed when `url` is set. */
+    apiKey?: string;
+    /** Custom base URL (e.g. a proxy that injects the key server-side).
+     *  When set, requests go to `${url}/v1/{chain}/…` with no key param. */
+    url?: string;
     timeoutMs: number;
   };
   alchemy?: {
-    apiKey: string;
+    /** API key for direct Alchemy access. Not needed when `url` is set. */
+    apiKey?: string;
+    /** Custom base URL (e.g. a proxy that injects the key server-side).
+     *  When set, requests go to `${url}/{chain}` with no key in the path. */
+    url?: string;
     timeoutMs: number;
   };
 }


### PR DESCRIPTION
## Summary

- Add optional `url` field to `IndexerConfig` for both GoldRush and Alchemy providers
- When `url` is set, indexer requests route to the custom URL with no API key in the request
- When only `apiKey` is set, behavior is identical to before (direct API calls with key in URL)
- `apiKey` is now optional on the type — callers using `url` don't need to provide one

This enables routing indexer requests through a proxy that injects API keys server-side, keeping them out of client bundles.

### Usage

```typescript
// Before (still works, unchanged)
evmIndexers: {
  goldRush: { apiKey: "cqt_...", timeoutMs: 5000 },
  alchemy: { apiKey: "abc...", timeoutMs: 5000 },
}

// New: custom URL (no apiKey needed)
evmIndexers: {
  goldRush: { url: "https://indexer.example.com/goldrush", timeoutMs: 5000 },
  alchemy: { url: "https://indexer.example.com/alchemy/v2", timeoutMs: 5000 },
}
```

### URL patterns when using custom URL

- **GoldRush**: \`\${url}/v1/{chain}/address/{wallet}/balances_v2/\` (no \`?key=\` param)
- **Alchemy**: \`\${url}/{chain}\` (no key in path, POST JSON-RPC body)

## Test plan

- [x] All 23 existing indexer tests pass — no behavior change for apiKey callers
- [x] Integration test with a live proxy endpoint