### PR TITLE
fix: use absolute offset for payload in deserializeUnknownVaa

### DIFF
--- a/core/definitions/__tests__/unknownVaa.ts
+++ b/core/definitions/__tests__/unknownVaa.ts
@@ -1,0 +1,39 @@
+import { deserializeUnknownVaa } from "../src/vaa/index.js";
+
+const headerLen = 1 + 4 + 1 + 1 + 65; // version + guardianSet + sigCount + (guardianIndex + signature)
+const envelopeLen = 4 + 4 + 2 + 32 + 8 + 1;
+
+const buildVaa = (payload: Uint8Array): Uint8Array => {
+  const data = new Uint8Array(headerLen + envelopeLen + payload.length);
+  const view = new DataView(data.buffer);
+
+  view.setUint8(0, 1); // version
+  view.setUint32(1, 7); // guardian set index
+  view.setUint8(5, 1); // signature count
+  view.setUint8(6, 0); // guardian index
+  data.fill(0xaa, 7, 7 + 65); // signature
+
+  view.setUint32(headerLen, 1700000000); // timestamp
+  view.setUint32(headerLen + 4, 42); // nonce
+  view.setUint16(headerLen + 8, 65535); // emitter chain, unknown to the SDK
+  data.fill(0x11, headerLen + 10, headerLen + 42); // emitter address
+  view.setBigUint64(headerLen + 42, 3n); // sequence
+  view.setUint8(headerLen + 50, 1); // consistency level
+
+  data.set(payload, headerLen + envelopeLen);
+  return data;
+};
+
+describe("Unknown VAA deserialization", function () {
+  it("should return exactly the payload bytes of a VAA from an unknown chain", function () {
+    const payload = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04]);
+    const vaa = deserializeUnknownVaa(buildVaa(payload));
+
+    expect(vaa.timestamp).toBe(1700000000);
+    expect(vaa.nonce).toBe(42);
+    expect(vaa.emitterChain).toBe(65535);
+    expect(vaa.sequence).toBe(3n);
+    expect(vaa.consistencyLevel).toBe(1);
+    expect(vaa.payload).toEqual(payload);
+  });
+});

--- a/core/definitions/src/vaa/functions.ts
+++ b/core/definitions/src/vaa/functions.ts
@@ -331,6 +331,6 @@ export const deserializeUnknownVaa = (data: Uint8Array) => {
   return {
     ...header,
     ...envelope,
-    payload: data.slice(offset2),
+    payload: data.slice(offset + offset2),
   };
 };


### PR DESCRIPTION
## Problem

`deserializeUnknownVaa` (`core/definitions/src/vaa/functions.ts`) returns a corrupted `payload`. It parses the envelope from `data.subarray(offset)` but then slices the payload from the original buffer using the envelope-relative `offset2`, never adding the header length.

Harness numbers (synthetic 1-signature VAA, 72-byte header, 51-byte envelope, true 8-byte payload `deadbeef01020304`):

- VAA total length: 131 bytes
- returned `payload.length`: 80 (expected 8)
- returned payload is prefixed with the signature tail and the full envelope before the real payload: `aaaa...aa 0000000000000007 0002 1111...11 0000000000000003 01 deadbeef01020304`
- payload equals truth: false

Header and envelope fields themselves parse correctly; only `payload` is affected. `deserializeUnknownVaa` is the exported helper for parsing VAAs from chains the SDK does not know yet (new chain integrations, indexers, explorers, custom relayers), so every such consumer silently receives a payload prefixed with signature/envelope bytes.

## Root cause

`offset2` is relative to the envelope subarray, but `data.slice(offset2)` applies it to the full VAA buffer, so the payload starts `offset` bytes too early (header length = 6 + 66 * numSignatures).

## Fix

One line: `payload: data.slice(offset + offset2)`.

## Regression test

Adds `core/definitions/__tests__/unknownVaa.ts`, which builds a synthetic VAA (valid header + envelope + known payload) and asserts the parsed payload equals the true payload bytes, plus envelope field assertions. Red before the fix (80 bytes returned instead of 8, prefixed with signature and envelope bytes), green after. Full `core/definitions` suite: 9 suites, 25 passed, 1 pre-existing skip.

## Notes

- The touched file at base commit `12489add` is content-identical to the published `@wormhole-foundation/sdk-definitions@6.1.5`.
- The function has no in-repo consumers; impact is integrator-facing.

Fix and regression test developed with AI assistance (Cursor agent); verified locally against the package jest suite.

Made with [Cursor](https://cursor.com)