### PR TITLE
fix: parse all-digit base58 Solana addresses as base58, not hex

### DIFF
--- a/platforms/solana/__tests__/unit/address.test.ts
+++ b/platforms/solana/__tests__/unit/address.test.ts
@@ -1,0 +1,27 @@
+import { encoding } from '@wormhole-foundation/sdk-connect';
+import { SolanaAddress, SolanaZeroAddress } from './../../src/index.js';
+
+describe('SolanaAddress tests', () => {
+  test('parses the all-digits base58 zero address as base58, not hex', () => {
+    const address = new SolanaAddress(SolanaZeroAddress);
+    expect(address.toString()).toBe(SolanaZeroAddress);
+    expect(address.toUint8Array()).toEqual(new Uint8Array(32));
+  });
+
+  test('round-trips a regular base58 address', () => {
+    const wsolMint = 'So11111111111111111111111111111111111111112';
+    expect(new SolanaAddress(wsolMint).toString()).toBe(wsolMint);
+  });
+
+  test('still parses 64-char hex strings as hex', () => {
+    const bytes = new Uint8Array(32).fill(1);
+    const hex = encoding.hex.encode(bytes);
+    expect(new SolanaAddress(hex).toUint8Array()).toEqual(bytes);
+  });
+
+  test('still parses 0x-prefixed hex strings as hex', () => {
+    const bytes = new Uint8Array(32).fill(2);
+    const hex = `0x${encoding.hex.encode(bytes)}`;
+    expect(new SolanaAddress(hex).toUint8Array()).toEqual(bytes);
+  });
+});

--- a/platforms/solana/src/address.ts
+++ b/platforms/solana/src/address.ts
@@ -24,7 +24,11 @@ export class SolanaAddress implements Address {
       this.address = address.address;
     } else if (UniversalAddress.instanceof(address)) {
       this.address = new PublicKey(address.toUint8Array());
-    } else if (typeof address === 'string' && encoding.hex.valid(address)) {
+    } else if (
+      typeof address === 'string' &&
+      encoding.hex.valid(address) &&
+      (address.startsWith('0x') || address.length === 64)
+    ) {
       this.address = new PublicKey(encoding.hex.decode(address));
     } else {
       this.address = new PublicKey(address);


### PR DESCRIPTION
## Problem

`SolanaAddress` checks `encoding.hex.valid(address)` (`/^(?:0x)?[0-9a-fA-F]+$/`) before falling through to base58 decoding. Any base58 string that happens to contain only hex characters takes the hex branch and is silently mis-derived. The most prominent victim is the system program / zero address `11111111111111111111111111111111`, which this package itself exports as `SolanaZeroAddress`.

Harness numbers (published `@wormhole-foundation/sdk-solana@6.1.5`, identical code at base commit):

- input: `11111111111111111111111111111111`
- `new SolanaAddress(input).toString()`: `111111111111111137EWfWxhwVEGTT5BcjfE2L`
- round-trip equal: false

The canonical zero address silently maps to an unrelated public key (the 32-character string is hex-decoded to 16 bytes). `@solana/web3.js` `PublicKey` accepts arbitrary-length byte input without a 32-byte check, so nothing downstream catches it. Any integrator passing an all-hex-character base58 address string gets a wrong recipient with no error; the realistic trigger is sentinel/well-known addresses like the system program, used in burn, SOL-wrap, and no-recipient idioms.

## Root cause

The hex branch regex matches any all-hex-character string, so all-digit (or otherwise hex-only) base58 strings are hex-decoded instead of base58-decoded.

## Fix

Gate the hex branch on an explicit `0x` prefix or an exact 64-character length (32 bytes, the only valid Solana address size): `address.startsWith('0x') || address.length === 64`. A base58 encoding of a 32-byte key is at most 44 characters, so a 64-character string can only be hex and the gate is unambiguous.

Behavior change is confined to bare, non-prefixed hex strings of lengths other than 64 characters, which were never a valid canonical Solana address encoding; those now decode as base58. `0x`-prefixed hex and bare 64-character hex behave exactly as before.

## Regression test

Adds `platforms/solana/__tests__/unit/address.test.ts` with four cases: zero-address round-trip (red before the fix with the exact mis-derived output above, green after), regular base58 round-trip, 64-character hex, and `0x`-prefixed hex (the latter three pass before and after, guarding the preserved paths). Full solana unit suite shows no new failures (the one failing case in `platform.test.ts` fails identically at pristine base; it requires a live RPC).

## Notes

- The touched file at base commit `12489add` is content-identical to the published `@wormhole-foundation/sdk-solana@6.1.5`.
- Related hardening idea, deliberately not included to keep this change minimal: `UniversalAddress`'s byte-path constructor does not enforce a length invariant, but it also serves 20-byte EVM addresses, so any change there needs a wider design discussion.

Fix and regression test developed with AI assistance (Cursor agent); verified locally against the package jest suite.

Made with [Cursor](https://cursor.com)